### PR TITLE
INTPYTHON-393 Remove ObjectIdAutoField acceptance of integer values

### DIFF
--- a/django_mongodb_backend/features.py
+++ b/django_mongodb_backend/features.py
@@ -205,6 +205,8 @@ class DatabaseFeatures(BaseDatabaseFeatures):
             "lookup.tests.LookupTests.test_in_ignore_none_with_unhashable_items",
             "m2m_through_regress.tests.ThroughLoadDataTestCase.test_sequence_creation",
             "many_to_many.tests.ManyToManyTests.test_add_remove_invalid_type",
+            "many_to_one.tests.ManyToOneTests.test_fk_to_smallautofield",
+            "many_to_one.tests.ManyToOneTests.test_fk_to_bigautofield",
             "migrations.test_operations.OperationTests.test_autofield__bigautofield_foreignfield_growth",
             "migrations.test_operations.OperationTests.test_model_with_bigautofield",
             "migrations.test_operations.OperationTests.test_smallfield_autofield_foreignfield_growth",
@@ -213,6 +215,8 @@ class DatabaseFeatures(BaseDatabaseFeatures):
             "model_fields.test_autofield.BigAutoFieldTests",
             "model_fields.test_autofield.SmallAutoFieldTests",
             "queries.tests.TestInvalidValuesRelation.test_invalid_values",
+            "schema.tests.SchemaTests.test_alter_autofield_pk_to_bigautofield_pk",
+            "schema.tests.SchemaTests.test_alter_autofield_pk_to_smallautofield_pk",
         },
         "Converters aren't run on returning fields from insert.": {
             # Unsure this is needed for this backend. Can implement by request.
@@ -231,6 +235,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
             "queries.test_qs_combinators.QuerySetSetOperationTests.test_order_raises_on_non_selected_column",
             "queries.tests.RelatedLookupTypeTests.test_values_queryset_lookup",
             "queries.tests.ValuesSubqueryTests.test_values_in_subquery",
+            "sites_tests.tests.CreateDefaultSiteTests.test_no_site_id",
         },
         "Cannot use QuerySet.delete() when querying across multiple collections on MongoDB.": {
             "admin_changelist.tests.ChangeListTests.test_distinct_for_many_to_many_at_second_level_in_search_fields",

--- a/docs/source/contents.rst
+++ b/docs/source/contents.rst
@@ -13,6 +13,7 @@ Table of contents
     intro/index
     topics/index
     ref/index
+    howto/index
     faq
     releases/index
     internals

--- a/docs/source/howto/contrib-apps.rst
+++ b/docs/source/howto/contrib-apps.rst
@@ -1,0 +1,26 @@
+=================================
+Configuring Django's contrib apps
+=================================
+
+Generally, Django's contribs app work out of the box, but here are some
+required adjustments.
+
+``contrib.sites``
+=================
+
+Usually the :doc:`sites framework <django:ref/contrib/sites>` requires the
+:setting:`SITE_ID` setting to be an integer corresponding to the primary key of
+the :class:`~django.contrib.sites.models.Site` object. For MongoDB, however,
+all primary keys are :class:`~bson.objectid.ObjectId`\s, and so
+:setting:`SITE_ID` must be set accordingly::
+
+    from bson import ObjectId
+
+    SITE_ID = ObjectId("000000000000000000000001")
+
+You must also use the :setting:`SILENCED_SYSTEM_CHECKS` setting to suppress
+Django's system check requiring :setting:`SITE_ID` to be an integer::
+
+    SILENCED_SYSTEM_CHECKS = [
+        "sites.E101",  # SITE_ID must be an ObjectId for MongoDB.
+    ]

--- a/docs/source/howto/index.rst
+++ b/docs/source/howto/index.rst
@@ -1,0 +1,13 @@
+=============
+How-to guides
+=============
+
+Practical guides covering common tasks and problems.
+
+Project configuration
+=====================
+
+.. toctree::
+   :maxdepth: 1
+
+   contrib-apps

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,7 +12,8 @@ First steps
 **Getting started:**
 
 - :doc:`Installation <intro/install>`
-- :doc:`Configuration <intro/configure>`
+- :doc:`Configuring a project <intro/configure>`
+- :doc:`howto/contrib-apps`
 
 Getting help
 ============

--- a/docs/source/intro/configure.rst
+++ b/docs/source/intro/configure.rst
@@ -155,3 +155,7 @@ it into the format above, you can use
 This constructs a :setting:`DATABASES` setting equivalent to the first example.
 
 Congratulations, your project is ready to go!
+
+.. seealso::
+
+    :doc:`/howto/contrib-apps`

--- a/docs/source/releases/5.0.x.rst
+++ b/docs/source/releases/5.0.x.rst
@@ -7,6 +7,10 @@ Django MongoDB Backend 5.0.x
 
 *Unreleased*
 
+- Backward-incompatible:
+  :class:`~django_mongodb_backend.fields.ObjectIdAutoField` no longer accepts
+  integer values. The undocumented behavior eased testing with Django's test
+  suite which hardcodes many integer primary key values.
 - Fixed the inability to save nested embedded model forms.
 - Fixed :ref:`persistent database connections
   <django:persistent-database-connections>`.

--- a/docs/source/releases/5.1.x.rst
+++ b/docs/source/releases/5.1.x.rst
@@ -7,6 +7,10 @@ Django MongoDB Backend 5.1.x
 
 *Unreleased*
 
+- Backward-incompatible:
+  :class:`~django_mongodb_backend.fields.ObjectIdAutoField` no longer accepts
+  integer values. The undocumented behavior eased testing with Django's test
+  suite which hardcodes many integer primary key values.
 - Fixed the inability to save nested embedded model forms.
 - Fixed :ref:`persistent database connections
   <django:persistent-database-connections>`.

--- a/tests/indexes_/test_condition.py
+++ b/tests/indexes_/test_condition.py
@@ -34,7 +34,7 @@ class PartialIndexTests(TestCase):
             Index(
                 name="test",
                 fields=["headline"],
-                condition=~Q(pk=True),
+                condition=~Q(pk__isnull=True),
             )._get_condition_mql(Article, schema_editor=editor)
 
     def test_xor_not_supported(self):
@@ -43,7 +43,7 @@ class PartialIndexTests(TestCase):
             Index(
                 name="test",
                 fields=["headline"],
-                condition=Q(pk=True) ^ Q(pk=False),
+                condition=Q(pk__isnull=True) ^ Q(pk__isnull=False),
             )._get_condition_mql(Article, schema_editor=editor)
 
     def test_operations(self):

--- a/tests/model_fields_/test_autofield.py
+++ b/tests/model_fields_/test_autofield.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import ValidationError
 from django.test import SimpleTestCase
 
 from django_mongodb_backend.fields import ObjectIdAutoField
@@ -15,6 +16,8 @@ class MethodTests(SimpleTestCase):
         f = ObjectIdAutoField()
         self.assertEqual(f.get_internal_type(), "ObjectIdAutoField")
 
-    def test_to_python(self):
+    def test_to_python_invalid_value(self):
         f = ObjectIdAutoField()
-        self.assertEqual(f.to_python("1"), 1)
+        msg = "“1” is not a valid Object Id."
+        with self.assertRaisesMessage(ValidationError, msg):
+            f.to_python("1")


### PR DESCRIPTION
fixes [INTPYTHON-393](https://jira.mongodb.org/browse/INTPYTHON-393)

Most of the work for this is adapting Django's test suite: https://github.com/mongodb-forks/django/pull/15