### PR TITLE
INTPYTHON-506 - Add django-rest-framework tests

### DIFF
--- a/tests/rest_framework_/test_filters.py
+++ b/tests/rest_framework_/test_filters.py
@@ -1,0 +1,276 @@
+# Based on https://github.com/encode/django-rest-framework/blob/0e1c7d3613905a8f9db69abb82f883e22e967119/tests/test_filters.py
+
+from collections import OrderedDict
+from importlib import reload as reload_module
+
+
+from django.db import models
+from django.db.models import CharField, Transform
+from django.test import TestCase
+from django.test.utils import override_settings
+
+from rest_framework.exceptions import ValidationError
+from rest_framework import filters, generics, serializers
+from rest_framework.test import APIRequestFactory
+
+factory = APIRequestFactory()
+
+
+class SearchFilterModel(models.Model):
+    title = models.CharField(max_length=20)
+    text = models.CharField(max_length=100)
+
+
+class SearchFilterSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = SearchFilterModel
+        fields = '__all__'
+
+
+class SearchFilterTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        # Sequence of title/text is:
+        #
+        # z   abc
+        # zz  bcd
+        # zzz cde
+        # ...
+        searchfilters = OrderedDict()
+        for idx in range(10):
+            title = 'z' * (idx + 1)
+            text = (
+                chr(idx + ord('a')) +
+                chr(idx + ord('b')) +
+                chr(idx + ord('c'))
+            )
+            searchfilter = SearchFilterModel(title=title, text=text)
+            searchfilter.save()
+            searchfilters[idx] = searchfilter
+
+
+        idx += 1
+        searchfilter = SearchFilterModel(title='A title', text='The long text')
+        searchfilter.save()
+        searchfilters[idx] = searchfilter
+
+        idx += 1
+        searchfilter = SearchFilterModel(title='The title', text='The "text')
+        searchfilter.save()
+        searchfilters[idx] = searchfilter
+
+        cls.searchfilters = searchfilters
+
+    def test_search(self):
+        class SearchListView(generics.ListAPIView):
+            queryset = SearchFilterModel.objects.all()
+            serializer_class = SearchFilterSerializer
+            filter_backends = (filters.SearchFilter,)
+            search_fields = ('title', 'text')
+
+        view = SearchListView.as_view()
+        request = factory.get('/', {'search': 'b'})
+        response = view(request)
+        assert response.data == [
+            {'id': self.searchfilters.get(0).id, 'title': 'z', 'text': 'abc'},
+            {'id': self.searchfilters.get(1).id, 'title': 'zz', 'text': 'bcd'}
+        ]
+
+    def test_search_returns_same_queryset_if_no_search_fields_or_terms_provided(self):
+        class SearchListView(generics.ListAPIView):
+            queryset = SearchFilterModel.objects.all()
+            serializer_class = SearchFilterSerializer
+            filter_backends = (filters.SearchFilter,)
+
+        view = SearchListView.as_view()
+        request = factory.get('/')
+        response = view(request)
+        expected = SearchFilterSerializer(SearchFilterModel.objects.all(),
+                                          many=True).data
+        assert response.data == expected
+
+    def test_exact_search(self):
+        class SearchListView(generics.ListAPIView):
+            queryset = SearchFilterModel.objects.all()
+            serializer_class = SearchFilterSerializer
+            filter_backends = (filters.SearchFilter,)
+            search_fields = ('=title', 'text')
+
+        view = SearchListView.as_view()
+        request = factory.get('/', {'search': 'zzz'})
+        response = view(request)
+        assert response.data == [
+            {'id': self.searchfilters.get(2).id, 'title': 'zzz', 'text': 'cde'}
+        ]
+
+    def test_startswith_search(self):
+        class SearchListView(generics.ListAPIView):
+            queryset = SearchFilterModel.objects.all()
+            serializer_class = SearchFilterSerializer
+            filter_backends = (filters.SearchFilter,)
+            search_fields = ('title', '^text')
+
+        view = SearchListView.as_view()
+        request = factory.get('/', {'search': 'b'})
+        response = view(request)
+        assert response.data == [
+            {'id': self.searchfilters.get(1).id, 'title': 'zz', 'text': 'bcd'}
+        ]
+
+    def test_regexp_search(self):
+        class SearchListView(generics.ListAPIView):
+            queryset = SearchFilterModel.objects.all()
+            serializer_class = SearchFilterSerializer
+            filter_backends = (filters.SearchFilter,)
+            search_fields = ('$title', '$text')
+
+        view = SearchListView.as_view()
+        request = factory.get('/', {'search': 'z{2} ^b'})
+        response = view(request)
+        assert response.data == [
+            {'id': self.searchfilters.get(1).id, 'title': 'zz', 'text': 'bcd'}
+        ]
+
+    def test_search_with_nonstandard_search_param(self):
+        with override_settings(REST_FRAMEWORK={'SEARCH_PARAM': 'query'}):
+            reload_module(filters)
+
+            class SearchListView(generics.ListAPIView):
+                queryset = SearchFilterModel.objects.all()
+                serializer_class = SearchFilterSerializer
+                filter_backends = (filters.SearchFilter,)
+                search_fields = ('title', 'text')
+
+            view = SearchListView.as_view()
+            request = factory.get('/', {'query': 'b'})
+            response = view(request)
+            assert response.data == [
+                {'id': self.searchfilters.get(0).id, 'title': 'z', 'text': 'abc'},
+                {'id': self.searchfilters.get(1).id, 'title': 'zz', 'text': 'bcd'}
+            ]
+
+        reload_module(filters)
+
+    def test_search_with_filter_subclass(self):
+        class CustomSearchFilter(filters.SearchFilter):
+            # Filter that dynamically changes search fields
+            def get_search_fields(self, view, request):
+                if request.query_params.get('title_only'):
+                    return ('$title',)
+                return super().get_search_fields(view, request)
+
+        class SearchListView(generics.ListAPIView):
+            queryset = SearchFilterModel.objects.all()
+            serializer_class = SearchFilterSerializer
+            filter_backends = (CustomSearchFilter,)
+            search_fields = ('$title', '$text')
+
+        view = SearchListView.as_view()
+        request = factory.get('/', {'search': r'^\w{3}$'})
+        response = view(request)
+        assert len(response.data) == 10
+
+        request = factory.get('/', {'search': r'^\w{3}$', 'title_only': 'true'})
+        response = view(request)
+        assert response.data == [
+            {'id': self.searchfilters.get(2).id, 'title': 'zzz', 'text': 'cde'}
+        ]
+
+    def test_search_field_with_null_characters(self):
+        view = generics.GenericAPIView()
+        request = factory.get('/?search=\0as%00d\x00f')
+        request = view.initialize_request(request)
+
+        with self.assertRaises(ValidationError):
+            filters.SearchFilter().get_search_terms(request)
+
+    def test_search_field_with_custom_lookup(self):
+        class SearchListView(generics.ListAPIView):
+            queryset = SearchFilterModel.objects.all()
+            serializer_class = SearchFilterSerializer
+            filter_backends = (filters.SearchFilter,)
+            search_fields = ('text__iendswith',)
+        view = SearchListView.as_view()
+        request = factory.get('/', {'search': 'c'})
+        response = view(request)
+        assert response.data == [
+            {'id': self.searchfilters.get(0).id, 'title': 'z', 'text': 'abc'},
+        ]
+
+    def test_search_field_with_additional_transforms(self):
+        from django.test.utils import register_lookup
+
+        class SearchListView(generics.ListAPIView):
+            queryset = SearchFilterModel.objects.all()
+            serializer_class = SearchFilterSerializer
+            filter_backends = (filters.SearchFilter,)
+            search_fields = ('text__trim', )
+
+        view = SearchListView.as_view()
+
+        # an example custom transform, that trims `a` from the string.
+        class TrimA(Transform):
+            function = 'TRIM'
+            lookup_name = 'trim'
+
+            def as_sql(self, compiler, connection):
+                sql, params = compiler.compile(self.lhs)
+                return "trim(%s, 'a')" % sql, params
+
+        with register_lookup(CharField, TrimA):
+            # Search including `a`
+            request = factory.get('/', {'search': 'abc'})
+
+            response = view(request)
+            assert response.data == []
+
+            # Search excluding `a`
+            request = factory.get('/', {'search': 'bc'})
+            response = view(request)
+            assert response.data == [
+                {'id': 1, 'title': 'z', 'text': 'abc'},
+                {'id': 2, 'title': 'zz', 'text': 'bcd'},
+            ]
+
+    def test_search_field_with_multiple_words(self):
+        class SearchListView(generics.ListAPIView):
+            queryset = SearchFilterModel.objects.all()
+            serializer_class = SearchFilterSerializer
+            filter_backends = (filters.SearchFilter,)
+            search_fields = ('title', 'text')
+
+        search_query = 'foo bar,baz'
+        view = SearchListView()
+        request = factory.get('/', {'search': search_query})
+        request = view.initialize_request(request)
+
+        rendered_search_field = filters.SearchFilter().to_html(
+            request=request, queryset=view.queryset, view=view
+        )
+        assert search_query in rendered_search_field
+
+    def test_search_field_with_escapes(self):
+        class SearchListView(generics.ListAPIView):
+            queryset = SearchFilterModel.objects.all()
+            serializer_class = SearchFilterSerializer
+            filter_backends = (filters.SearchFilter,)
+            search_fields = ('title', 'text',)
+        view = SearchListView.as_view()
+        request = factory.get('/', {'search': '"\\\"text"'})
+        response = view(request)
+        assert response.data == [
+            {'id': self.searchfilters.get(11).id, 'title': 'The title', 'text': 'The "text'},
+        ]
+
+    def test_search_field_with_quotes(self):
+        class SearchListView(generics.ListAPIView):
+            queryset = SearchFilterModel.objects.all()
+            serializer_class = SearchFilterSerializer
+            filter_backends = (filters.SearchFilter,)
+            search_fields = ('title', 'text',)
+        view = SearchListView.as_view()
+        request = factory.get('/', {'search': '"long text"'})
+        response = view(request)
+        assert response.data == [
+            {'id': self.searchfilters.get(10).id, 'title': 'A title', 'text': 'The long text'},
+        ]


### PR DESCRIPTION
Based on
- PR out of scope: https://github.com/encode/django-rest-framework/pull/9656
- Most DRF tests already passing as of 18e7177def01c4ed9decc01a1e25aba2b9efffa5
- drf-extensions not necessarily the right place for our integration testing

I've added and fixed 13 DRF tests here that are a subset of the 158 failed tests (1330 passing) as of 18e7177def01c4ed9decc01a1e25aba2b9efffa5.

Here's the test run:

```
…
test_exact_search (rest_framework_.test_filters.SearchFilterTests.test_exact_search) ... ok
(0.000) db.rest_framework__searchfiltermodel.aggregate([{'$match': {'$expr': {'$or': [{'$regexMatch': {'input': {'$toString': '$title'}, 'regex': {'$concat': ('^', 'zzz', {'$literal': '$'})}, 'options': 'i'}}, {'$regexMatch': {'input': {'$toString': '$text'}, 'regex': 'zzz', 'options': 'i'}}]}}}])
----------------------------------------------------------------------
test_regexp_search (rest_framework_.test_filters.SearchFilterTests.test_regexp_search) ... ok
(0.000) db.rest_framework__searchfiltermodel.aggregate([{'$match': {'$expr': {'$and': [{'$or': [{'$regexMatch': {'input': {'$toString': '$title'}, 'regex': 'z{2}', 'options': 'i'}}, {'$regexMatch': {'input': {'$toString': '$text'}, 'regex': 'z{2}', 'options': 'i'}}]}, {'$or': [{'$regexMatch': {'input': {'$toString': '$title'}, 'regex': '^b', 'options': 'i'}}, {'$regexMatch': {'input': {'$toString': '$text'}, 'regex': '^b', 'options': 'i'}}]}]}}}])
----------------------------------------------------------------------
test_search (rest_framework_.test_filters.SearchFilterTests.test_search) ... ok
(0.000) db.rest_framework__searchfiltermodel.aggregate([{'$match': {'$expr': {'$or': [{'$regexMatch': {'input': {'$toString': '$title'}, 'regex': 'b', 'options': 'i'}}, {'$regexMatch': {'input': {'$toString': '$text'}, 'regex': 'b', 'options': 'i'}}]}}}])
----------------------------------------------------------------------
test_search_field_with_additional_transforms (rest_framework_.test_filters.SearchFilterTests.test_search_field_with_additional_transforms) ... ERROR
----------------------------------------------------------------------
test_search_field_with_custom_lookup (rest_framework_.test_filters.SearchFilterTests.test_search_field_with_custom_lookup) ... ok
(0.000) db.rest_framework__searchfiltermodel.aggregate([{'$match': {'$expr': {'$regexMatch': {'input': {'$toString': '$text'}, 'regex': {'$concat': ('c', {'$literal': '$'})}, 'options': 'i'}}}}])
----------------------------------------------------------------------
test_search_field_with_escapes (rest_framework_.test_filters.SearchFilterTests.test_search_field_with_escapes) ... ok
(0.000) db.rest_framework__searchfiltermodel.aggregate([{'$match': {'$expr': {'$or': [{'$regexMatch': {'input': {'$toString': '$title'}, 'regex': '"text', 'options': 'i'}}, {'$regexMatch': {'input': {'$toString': '$text'}, 'regex': '"text', 'options': 'i'}}]}}}])
----------------------------------------------------------------------
test_search_field_with_multiple_words (rest_framework_.test_filters.SearchFilterTests.test_search_field_with_multiple_words) ... ERROR
----------------------------------------------------------------------
test_search_field_with_null_characters (rest_framework_.test_filters.SearchFilterTests.test_search_field_with_null_characters) ... ok
----------------------------------------------------------------------
test_search_field_with_quotes (rest_framework_.test_filters.SearchFilterTests.test_search_field_with_quotes) ... ok
(0.000) db.rest_framework__searchfiltermodel.aggregate([{'$match': {'$expr': {'$or': [{'$regexMatch': {'input': {'$toString': '$title'}, 'regex': 'long\\ text', 'options': 'i'}}, {'$regexMatch': {'input': {'$toString': '$text'}, 'regex': 'long\\ text', 'options': 'i'}}]}}}])
----------------------------------------------------------------------
test_search_returns_same_queryset_if_no_search_fields_or_terms_provided (rest_framework_.test_filters.SearchFilterTests.test_search_returns_same_queryset_if_no_search_fields_or_terms_provided) ... ok
(0.000) db.rest_framework__searchfiltermodel.aggregate([{'$match': {'$expr': {}}}])
(0.000) db.rest_framework__searchfiltermodel.aggregate([{'$match': {'$expr': {}}}])
----------------------------------------------------------------------
test_search_with_filter_subclass (rest_framework_.test_filters.SearchFilterTests.test_search_with_filter_subclass) ... ok
(0.000) db.rest_framework__searchfiltermodel.aggregate([{'$match': {'$expr': {'$or': [{'$regexMatch': {'input': {'$toString': '$title'}, 'regex': '^\\w{3}$', 'options': 'i'}}, {'$regexMatch': {'input': {'$toString': '$text'}, 'regex': '^\\w{3}$', 'options': 'i'}}]}}}])
(0.000) db.rest_framework__searchfiltermodel.aggregate([{'$match': {'$expr': {'$regexMatch': {'input': {'$toString': '$title'}, 'regex': '^\\w{3}$', 'options': 'i'}}}}])
----------------------------------------------------------------------
test_search_with_nonstandard_search_param (rest_framework_.test_filters.SearchFilterTests.test_search_with_nonstandard_search_param) ... ok
(0.000) db.rest_framework__searchfiltermodel.aggregate([{'$match': {'$expr': {'$or': [{'$regexMatch': {'input': {'$toString': '$title'}, 'regex': 'b', 'options': 'i'}}, {'$regexMatch': {'input': {'$toString': '$text'}, 'regex': 'b', 'options': 'i'}}]}}}])
----------------------------------------------------------------------
test_startswith_search (rest_framework_.test_filters.SearchFilterTests.test_startswith_search) ... ok
(0.000) db.rest_framework__searchfiltermodel.aggregate([{'$match': {'$expr': {'$or': [{'$regexMatch': {'input': {'$toString': '$title'}, 'regex': 'b', 'options': 'i'}}, {'$regexMatch': {'input': {'$toString': '$text'}, 'regex': {'$concat': ('^', 'b')}, 'options': 'i'}}]}}}])
----------------------------------------------------------------------

======================================================================
ERROR: test_search_field_with_additional_transforms (rest_framework_.test_filters.SearchFilterTests.test_search_field_with_additional_transforms)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/alex.clark/Developer/django-mongodb-cli/src/django-mongodb-backend/django_mongodb_backend/query.py", line 19, in wrapper
    return func(*args, **kwargs)
  File "/Users/alex.clark/Developer/django-mongodb-cli/src/django-mongodb-backend/django_mongodb_backend/query.py", line 74, in get_cursor
    return self.compiler.collection.aggregate(self.get_pipeline())
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
  File "/Users/alex.clark/Developer/django-mongodb-cli/src/django-mongodb-backend/django_mongodb_backend/utils.py", line 166, in wrapper
    duration, retval = self.profile_call(func, args, kwargs)
                       ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
  File "/Users/alex.clark/Developer/django-mongodb-cli/src/django-mongodb-backend/django_mongodb_backend/utils.py", line 131, in profile_call
    retval = func(*args, **kwargs or {})
  File "/Users/alex.clark/Developer/django-mongodb-cli/.venv/lib/python3.13/site-packages/pymongo/synchronous/collection.py", line 2978, in aggregate
    return self._aggregate(
           ~~~~~~~~~~~~~~~^
        _CollectionAggregationCommand,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<6 lines>...
        **kwargs,
        ^^^^^^^^^
    )
    ^
  File "/Users/alex.clark/Developer/django-mongodb-cli/.venv/lib/python3.13/site-packages/pymongo/_csot.py", line 119, in csot_wrapper
    return func(self, *args, **kwargs)
  File "/Users/alex.clark/Developer/django-mongodb-cli/.venv/lib/python3.13/site-packages/pymongo/synchronous/collection.py", line 2886, in _aggregate
    return self._database.client._retryable_read(
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        cmd.get_cursor,
        ^^^^^^^^^^^^^^^
    ...<3 lines>...
        operation=_Op.AGGREGATE,
        ^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/Users/alex.clark/Developer/django-mongodb-cli/.venv/lib/python3.13/site-packages/pymongo/synchronous/mongo_client.py", line 1861, in _retryable_read
    return self._retry_internal(
           ~~~~~~~~~~~~~~~~~~~~^
        func,
        ^^^^^
    ...<7 lines>...
        operation_id=operation_id,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/Users/alex.clark/Developer/django-mongodb-cli/.venv/lib/python3.13/site-packages/pymongo/_csot.py", line 119, in csot_wrapper
    return func(self, *args, **kwargs)
  File "/Users/alex.clark/Developer/django-mongodb-cli/.venv/lib/python3.13/site-packages/pymongo/synchronous/mongo_client.py", line 1828, in _retry_internal
    ).run()
      ~~~^^
  File "/Users/alex.clark/Developer/django-mongodb-cli/.venv/lib/python3.13/site-packages/pymongo/synchronous/mongo_client.py", line 2565, in run
    return self._read() if self._is_read else self._write()
           ~~~~~~~~~~^^
  File "/Users/alex.clark/Developer/django-mongodb-cli/.venv/lib/python3.13/site-packages/pymongo/synchronous/mongo_client.py", line 2708, in _read
    return self._func(self._session, self._server, conn, read_pref)  # type: ignore
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/alex.clark/Developer/django-mongodb-cli/.venv/lib/python3.13/site-packages/pymongo/synchronous/aggregation.py", line 164, in get_cursor
    result = conn.command(
        self._database.name,
    ...<9 lines>...
        user_fields=self._user_fields,
    )
  File "/Users/alex.clark/Developer/django-mongodb-cli/.venv/lib/python3.13/site-packages/pymongo/synchronous/helpers.py", line 47, in inner
    return func(*args, **kwargs)
  File "/Users/alex.clark/Developer/django-mongodb-cli/.venv/lib/python3.13/site-packages/pymongo/synchronous/pool.py", line 536, in command
    return command(
        self,
    ...<20 lines>...
        write_concern=write_concern,
    )
  File "/Users/alex.clark/Developer/django-mongodb-cli/.venv/lib/python3.13/site-packages/pymongo/synchronous/network.py", line 213, in command
    helpers_shared._check_command_response(
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        response_doc,
        ^^^^^^^^^^^^^
    ...<2 lines>...
        parse_write_concern_error=parse_write_concern_error,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/Users/alex.clark/Developer/django-mongodb-cli/.venv/lib/python3.13/site-packages/pymongo/helpers_shared.py", line 247, in _check_command_response
    raise OperationFailure(errmsg, code, response, max_wire_version)
pymongo.errors.OperationFailure: $trim only supports an object as an argument, found string, full error: {'ok': 0.0, 'errmsg': '$trim only supports an object as an argument, found string', 'code': 50696, 'codeName': 'Location50696'}

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/alex.clark/Developer/django-mongodb-cli/src/django-mongodb-backend/tests/rest_framework_/test_filters.py", line 224, in test_search_field_with_additional_transforms
    response = view(request)
  File "/Users/alex.clark/Developer/django-mongodb-cli/src/django/django/views/decorators/csrf.py", line 65, in _view_wrapper
    return view_func(request, *args, **kwargs)
  File "/Users/alex.clark/Developer/django-mongodb-cli/src/django/django/views/generic/base.py", line 104, in view
    return self.dispatch(request, *args, **kwargs)
           ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/alex.clark/Developer/django-mongodb-cli/src/django-rest-framework/rest_framework/views.py", line 515, in dispatch
    response = self.handle_exception(exc)
  File "/Users/alex.clark/Developer/django-mongodb-cli/src/django-rest-framework/rest_framework/views.py", line 475, in handle_exception
    self.raise_uncaught_exception(exc)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^
  File "/Users/alex.clark/Developer/django-mongodb-cli/src/django-rest-framework/rest_framework/views.py", line 486, in raise_uncaught_exception
    raise exc
  File "/Users/alex.clark/Developer/django-mongodb-cli/src/django-rest-framework/rest_framework/views.py", line 512, in dispatch
    response = handler(request, *args, **kwargs)
  File "/Users/alex.clark/Developer/django-mongodb-cli/src/django-rest-framework/rest_framework/generics.py", line 203, in get
    return self.list(request, *args, **kwargs)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/alex.clark/Developer/django-mongodb-cli/src/django-rest-framework/rest_framework/mixins.py", line 46, in list
    return Response(serializer.data)
                    ^^^^^^^^^^^^^^^
  File "/Users/alex.clark/Developer/django-mongodb-cli/src/django-rest-framework/rest_framework/serializers.py", line 797, in data
    ret = super().data
          ^^^^^^^^^^^^
  File "/Users/alex.clark/Developer/django-mongodb-cli/src/django-rest-framework/rest_framework/serializers.py", line 251, in data
    self._data = self.to_representation(self.instance)
                 ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/Users/alex.clark/Developer/django-mongodb-cli/src/django-rest-framework/rest_framework/serializers.py", line 716, in to_representation
    self.child.to_representation(item) for item in iterable
                                                   ^^^^^^^^
  File "/Users/alex.clark/Developer/django-mongodb-cli/src/django/django/db/models/query.py", line 400, in __iter__
    self._fetch_all()
    ~~~~~~~~~~~~~~~^^
  File "/Users/alex.clark/Developer/django-mongodb-cli/src/django/django/db/models/query.py", line 1928, in _fetch_all
    self._result_cache = list(self._iterable_class(self))
                         ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/alex.clark/Developer/django-mongodb-cli/src/django/django/db/models/query.py", line 91, in __iter__
    results = compiler.execute_sql(
        chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size
    )
  File "/Users/alex.clark/Developer/django-mongodb-cli/src/django-mongodb-backend/django_mongodb_backend/compiler.py", line 254, in execute_sql
    cursor = query.get_cursor()
  File "/Users/alex.clark/Developer/django-mongodb-cli/src/django-mongodb-backend/django_mongodb_backend/query.py", line 27, in wrapper
    raise DatabaseError from e
django.db.utils.DatabaseError

----------------------------------------------------------------------

======================================================================
ERROR: test_search_field_with_multiple_words (rest_framework_.test_filters.SearchFilterTests.test_search_field_with_multiple_words)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/alex.clark/Developer/django-mongodb-cli/src/django-mongodb-backend/tests/rest_framework_/test_filters.py", line 247, in test_search_field_with_multiple_words
    rendered_search_field = filters.SearchFilter().to_html(
        request=request, queryset=view.queryset, view=view
    )
  File "/Users/alex.clark/Developer/django-mongodb-cli/src/django-rest-framework/rest_framework/filters.py", line 186, in to_html
    template = loader.get_template(self.template)
  File "/Users/alex.clark/Developer/django-mongodb-cli/src/django/django/template/loader.py", line 19, in get_template
    raise TemplateDoesNotExist(template_name, chain=chain)
django.template.exceptions.TemplateDoesNotExist: rest_framework/filters/search.html

----------------------------------------------------------------------

----------------------------------------------------------------------
Ran 13 tests in 0.404s

FAILED (errors=2)
Destroying test database for alias 'default' ('test_djangotests')...
```

Can we include this here?
