### PR TITLE
Allow querying an EmbeddedModelField by model instance

### DIFF
--- a/docs/source/releases/5.2.x.rst
+++ b/docs/source/releases/5.2.x.rst
@@ -22,6 +22,7 @@ New features
   a model's :attr:`Meta.indexes <django.db.models.Options.indexes>`.
 - PyMongo's connection pooling is now used by default. See
   :ref:`connection-management`.
+- Allowed ``EmbeddedModelField``’s ``exact`` lookup to use a model instance.
 
 Backwards incompatible changes
 ------------------------------

--- a/docs/source/topics/embedded-models.rst
+++ b/docs/source/topics/embedded-models.rst
@@ -54,3 +54,16 @@ as relational fields. For example, to retrieve all customers who have an
 address with the city "New York"::
 
     >>> Customer.objects.filter(address__city="New York")
+
+You can also query using a model instance. Unlike a normal relational lookup
+which does the lookup by primary key, since embedded models typically don't
+have a primary key set, the query requires that every field match. For example,
+this query gives customers with addresses with the city "New York" and all
+other fields of the address equal to their default (:attr:`Field.default
+<django.db.models.Field.default>`, ``None``, or an empty string).
+
+    >>> Customer.objects.filter(address=Address(city="New York"))
+
+.. versionadded:: 5.2.0b0
+
+    The ability to query by model instance was added.

--- a/tests/model_fields_/models.py
+++ b/tests/model_fields_/models.py
@@ -138,3 +138,31 @@ class Library(models.Model):
 
     def __str__(self):
         return self.name
+
+
+class A(models.Model):
+    b = EmbeddedModelField("B")
+
+
+class B(EmbeddedModel):
+    c = EmbeddedModelField("C")
+    name = models.CharField(max_length=100)
+    value = models.IntegerField()
+
+
+class C(EmbeddedModel):
+    d = EmbeddedModelField("D")
+    name = models.CharField(max_length=100)
+    value = models.IntegerField()
+
+
+class D(EmbeddedModel):
+    e = EmbeddedModelField("E")
+    nullable_e = EmbeddedModelField("E", null=True, blank=True)
+    name = models.CharField(max_length=100)
+    value = models.IntegerField()
+
+
+class E(EmbeddedModel):
+    name = models.CharField(max_length=100)
+    value = models.IntegerField()

--- a/tests/model_fields_/test_embedded_model.py
+++ b/tests/model_fields_/test_embedded_model.py
@@ -2,7 +2,7 @@ import operator
 from datetime import timedelta
 
 from django.core.exceptions import FieldDoesNotExist, ValidationError
-from django.db import models
+from django.db import connection, models
 from django.db.models import (
     Exists,
     ExpressionWrapper,
@@ -17,15 +17,7 @@ from django.test.utils import isolate_apps
 from django_mongodb_backend.fields import EmbeddedModelField
 from django_mongodb_backend.models import EmbeddedModel
 
-from .models import (
-    Address,
-    Author,
-    Book,
-    Data,
-    Holder,
-    Library,
-    NestedData,
-)
+from .models import A, Address, Author, B, Book, C, D, Data, E, Holder, Library, NestedData
 from .utils import truncate_ms
 
 
@@ -144,6 +136,62 @@ class QueryingTests(TestCase):
     def test_order_by_embedded_field(self):
         qs = Holder.objects.filter(data__integer__gt=3).order_by("-data__integer")
         self.assertSequenceEqual(qs, list(reversed(self.objs[4:])))
+
+    def test_exact_with_model(self):
+        data = Holder.objects.first().data
+        self.assertEqual(
+            Holder.objects.filter(data=data).get().data.integer, self.objs[0].data.integer
+        )
+
+    def test_exact_with_model_ignores_key_order(self):
+        # Due to the possibility of schema changes or the reordering of a
+        # model's fields, a lookup must work if an embedded document has its
+        # keys in a different order than what's declared on the embedded model.
+        data = {}
+        for field in reversed(Data._meta.fields):
+            data[field.name] = None
+        del data["id"]
+        data["integer"] = 100
+        connection.get_collection("model_fields__holder").insert_one({"data": data})
+        self.assertEqual(Holder.objects.filter(data=Data(integer=100)).get().data.integer, 100)
+
+    def test_exact_with_nested_model(self):
+        address = Address(city="NYC", state="NY")
+        author = Author(name="Shakespeare", age=55, address=address)
+        obj = Book.objects.create(author=author)
+        self.assertCountEqual(Book.objects.filter(author=author), [obj])
+        self.assertCountEqual(Book.objects.filter(author__address=address), [obj])
+
+    def test_exact_with_deeply_nested_models(self):
+        e1 = E(name="E1", value=5)
+        d1 = D(name="D1", value=4, e=e1)
+        c1 = C(name="C1", value=3, d=d1)
+        b1 = B(name="B1", value=2, c=c1)
+        a1 = A.objects.create(b=b1)
+        e2 = E(name="E2", value=6)
+        d2 = D(name="D2", value=4, e=e1, nullable_e=e2)
+        c2 = C(name="C2", value=3, d=d2)
+        b2 = B(name="B2", value=2, c=c2)
+        a2 = A.objects.create(b=b2)
+        self.assertCountEqual(A.objects.filter(b=b1), [a1])
+        self.assertCountEqual(A.objects.filter(b__c=c1), [a1])
+        self.assertCountEqual(A.objects.filter(b__c__d=d1), [a1])
+        self.assertCountEqual(A.objects.filter(b__c__d__e=e1), [a1, a2])
+        self.assertCountEqual(A.objects.filter(b=b2), [a2])
+        self.assertCountEqual(A.objects.filter(b__c=c2), [a2])
+        self.assertCountEqual(A.objects.filter(b__c__d=d2), [a2])
+        self.assertCountEqual(A.objects.filter(b__c__d__nullable_e=e2), [a2])
+
+    def test_exact_validates_argument(self):
+        msg = "An EmbeddedModelField must be queried using a model instance, got <class 'dict'>."
+        with self.assertRaisesMessage(TypeError, msg):
+            str(A.objects.filter(b={}))
+        with self.assertRaisesMessage(TypeError, msg):
+            str(A.objects.filter(b__c={}))
+        with self.assertRaisesMessage(TypeError, msg):
+            str(A.objects.filter(b__c__d={}))
+        with self.assertRaisesMessage(TypeError, msg):
+            str(A.objects.filter(b__c__d__e={}))
 
     def test_embedded_json_field_lookups(self):
         objs = [


### PR DESCRIPTION
This feature may not be merged since it's not a best practice to query this way. It may also be not intuitive that unlike SQL, querying by model doesn't necessary return a unique result since the embedded document match is field by field rather than by primary key. Also, other MongoDB libraries don't support this pattern.