### PR TITLE
Fix QuerySet.raw_aggregate() when document key order differs from model field order

### DIFF
--- a/django_mongodb_backend/queryset.py
+++ b/django_mongodb_backend/queryset.py
@@ -93,4 +93,4 @@ class RawModelIterable(BaseRawModelIterable):
         of __iter__().
         """
         for result in query:
-            yield tuple(result.values())
+            yield tuple(result.get(key) for key in self.queryset.columns)

--- a/docs/source/releases/5.1.x.rst
+++ b/docs/source/releases/5.1.x.rst
@@ -8,6 +8,8 @@ Django MongoDB Backend 5.1.x
 *Unreleased*
 
 - Added support for :doc:`database caching </topics/cache>`.
+- Fixed ``QuerySet.raw_aggregate()`` field initialization when the document key
+  order doesn't match the order of the model's fields.
 
 5.1.0 beta 1
 ============


### PR DESCRIPTION
The order may differ in legacy databases, due to rearranging a model's fields, after a schema change, etc.