### PR TITLE
Add a better error message when a Func is missing as_mql()

### DIFF
--- a/django_mongodb_backend/functions.py
+++ b/django_mongodb_backend/functions.py
@@ -102,6 +102,8 @@ def extract(self, compiler, connection):
 
 def func(self, compiler, connection):
     lhs_mql = process_lhs(self, compiler, connection)
+    if self.function is None:
+        raise NotSupportedError(f"{self} may need an as_mql() method.")
     operator = MONGO_OPERATORS.get(self.__class__, self.function.lower())
     return {f"${operator}": lhs_mql}
 

--- a/tests/db_functions_/tests.py
+++ b/tests/db_functions_/tests.py
@@ -1,0 +1,10 @@
+from django.db import NotSupportedError
+from django.db.models import Func
+from django.test import SimpleTestCase
+
+
+class FuncTests(SimpleTestCase):
+    def test_no_as_mql(self):
+        msg = "Func() may need an as_mql() method."
+        with self.assertRaisesMessage(NotSupportedError, msg):
+            Func().as_mql(None, None)


### PR DESCRIPTION
I have seen this too many times:
```
  File "/home/tim/code/django-mongodb/django_mongodb_backend/functions.py", line 105, in func
    operator = MONGO_OPERATORS.get(self.__class__, self.function.lower())
                                                   ^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'lower'
```