### PR TITLE
INTPYTHON-574 Use persistent connections by default

### DIFF
--- a/django_mongodb_backend/base.py
+++ b/django_mongodb_backend/base.py
@@ -165,6 +165,10 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         settings_dict = self.settings_dict
         if not settings_dict["NAME"]:
             raise ImproperlyConfigured('settings.DATABASES is missing the "NAME" value.')
+        # Use persistent connections by default, even if the user specifies
+        # CONN_MAX_AGE=0. (This code has no way to distinguish that case.)
+        if settings_dict["CONN_MAX_AGE"] == 0:
+            settings_dict["CONN_MAX_AGE"] = None
         return {
             "host": settings_dict["HOST"] or None,
             "port": int(settings_dict["PORT"] or 27017),


### PR DESCRIPTION
After implementing this, I noticed a documentation note that persistent connections as implemented in Django aren't compatible with ASGI. https://code.djangoproject.com/ticket/33497#comment:51 I'm not sure if that's a concern for this library.

On the other hand, Django's documentation suggests to use connection pooling with ASGI, and I think we need to change this library to support that (i.e. not initialize a new `MongoClient` in every `get_new_connection()` call.