### PR TITLE
Drop support for MongoDB 6.0

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -68,22 +68,22 @@ tasks:
       - func: "run unit tests"
 
 buildvariants:
-  - name: tests-6-noauth-nossl
-    display_name: Run Tests 6.0 NoAuth NoSSL
+  - name: tests-7-noauth-nossl
+    display_name: Run Tests 7.0 NoAuth NoSSL
     run_on: rhel87-small
     expansions:
-      MONGODB_VERSION: "6.0"
+      MONGODB_VERSION: "7.0"
       TOPOLOGY: server
       AUTH: "noauth"
       SSL: "nossl"
     tasks:
       - name: run-tests
 
-  - name: tests-6-auth-ssl
-    display_name: Run Tests 6.0 Auth SSL
+  - name: tests-7-auth-ssl
+    display_name: Run Tests 7.0 Auth SSL
     run_on: rhel87-small
     expansions:
-      MONGODB_VERSION: "6.0"
+      MONGODB_VERSION: "7.0"
       TOPOLOGY: server
       AUTH: "auth"
       SSL: "ssl"

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -52,6 +52,6 @@ jobs:
       - name: Start MongoDB
         uses: supercharge/mongodb-github-action@1.12.0
         with:
-          mongodb-version: 6.0
+          mongodb-version: 7.0
       - name: Run tests
         run: python3 django_repo/tests/runtests_.py

--- a/django_mongodb_backend/features.py
+++ b/django_mongodb_backend/features.py
@@ -1,9 +1,8 @@
 from django.db.backends.base.features import BaseDatabaseFeatures
-from django.utils.functional import cached_property
 
 
 class DatabaseFeatures(BaseDatabaseFeatures):
-    minimum_database_version = (6, 0)
+    minimum_database_version = (7, 0)
     allow_sliced_subqueries_with_in = False
     allows_multiple_constraints_on_same_fields = False
     can_create_inline_fk = False
@@ -39,7 +38,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_unspecified_pk = True
     uses_savepoints = False
 
-    _django_test_expected_failures = {
+    django_test_expected_failures = {
         # $concat only supports strings, not int
         "db_functions.text.test_concat.ConcatTests.test_concat_non_str",
         # QuerySet.order_by() with annotation transform doesn't work:
@@ -89,23 +88,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         # https://jira.mongodb.org/browse/SERVER-99186
         "model_fields_.test_arrayfield.QueryingTests.test_contained_by_subquery",
     }
-    # $bitAnd, #bitOr, and $bitXor are new in MongoDB 6.3.
-    _django_test_expected_failures_bitwise = {
-        "expressions.tests.ExpressionOperatorTests.test_lefthand_bitwise_and",
-        "expressions.tests.ExpressionOperatorTests.test_lefthand_bitwise_or",
-        "expressions.tests.ExpressionOperatorTests.test_lefthand_bitwise_xor",
-        "expressions.tests.ExpressionOperatorTests.test_lefthand_bitwise_xor_null",
-        "expressions.tests.ExpressionOperatorTests.test_lefthand_bitwise_xor_right_null",
-        "expressions.tests.ExpressionOperatorTests.test_lefthand_transformed_field_bitwise_or",
-    }
-
-    @cached_property
-    def django_test_expected_failures(self):
-        expected_failures = super().django_test_expected_failures
-        expected_failures.update(self._django_test_expected_failures)
-        if not self.is_mongodb_6_3:
-            expected_failures.update(self._django_test_expected_failures_bitwise)
-        return expected_failures
 
     django_test_skips = {
         "Database defaults aren't supported by MongoDB.": {
@@ -607,7 +589,3 @@ class DatabaseFeatures(BaseDatabaseFeatures):
             "custom_lookups.tests.SubqueryTransformTests.test_subquery_usage",
         },
     }
-
-    @cached_property
-    def is_mongodb_6_3(self):
-        return self.connection.get_database_version() >= (6, 3)

--- a/docs/source/releases/5.1.x.rst
+++ b/docs/source/releases/5.1.x.rst
@@ -11,6 +11,8 @@ Django MongoDB Backend 5.1.x
   :attr:`~.ArrayField.size` parameter is renamed to
   :attr:`~.ArrayField.max_size`. The :attr:`~.ArrayField.size` parameter is now
   used to enforce fixed-length arrays.
+- Backward-incompatible: Bumped the minimum supported version of MongoDB from
+  6.0 to 7.0.
 - Added support for :doc:`database caching </topics/cache>`.
 - Fixed ``QuerySet.raw_aggregate()`` field initialization when the document key
   order doesn't match the order of the model's fields.


### PR DESCRIPTION
It will be end of life July 31, 2024.