### PR TITLE
Bump version to 5.1.0b2

### DIFF
--- a/django_mongodb_backend/__init__.py
+++ b/django_mongodb_backend/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "5.1.0.dev0"
+__version__ = "5.1.0b2"
 
 # Check Django compatibility before other imports which may fail if the
 # wrong version of Django is installed.

--- a/docs/source/releases/5.1.x.rst
+++ b/docs/source/releases/5.1.x.rst
@@ -5,7 +5,7 @@ Django MongoDB Backend 5.1.x
 5.1.0 beta 2
 ============
 
-*Unreleased*
+*April 18, 2025*
 
 - Backward-incompatible: :class:`~django_mongodb_backend.fields.ArrayField`\'s
   :attr:`~.ArrayField.size` parameter is renamed to


### PR DESCRIPTION
(After https://github.com/mongodb/django-mongodb-backend/pull/288, we bump the version ourselves rather than the release bot, right?)