### PR TITLE
INTPYTHON-574 Add support for connection pooling

### DIFF
--- a/django_mongodb_backend/creation.py
+++ b/django_mongodb_backend/creation.py
@@ -8,6 +8,9 @@ from django_mongodb_backend.management.commands.createcachecollection import (
 
 class DatabaseCreation(BaseDatabaseCreation):
     def _execute_create_test_db(self, cursor, parameters, keepdb=False):
+        # Close the connection (which may point to the non-test database) so
+        # that a new connection to the test database can be established later.
+        self.connection.close_pool()
         if not keepdb:
             self._destroy_test_db(parameters["dbname"], verbosity=0)
 
@@ -29,3 +32,8 @@ class DatabaseCreation(BaseDatabaseCreation):
             database=self.connection.alias, verbosity=kwargs["verbosity"]
         )
         return test_database_name
+
+    def destroy_test_db(self, old_database_name=None, verbosity=1, keepdb=False, suffix=None):
+        super().destroy_test_db(old_database_name, verbosity, keepdb, suffix)
+        # Close the connection to the test database.
+        self.connection.close_pool()

--- a/django_mongodb_backend/features.py
+++ b/django_mongodb_backend/features.py
@@ -72,7 +72,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         # Connection creation doesn't follow the usual Django API.
         "backends.tests.ThreadTests.test_pass_connection_between_threads",
         "backends.tests.ThreadTests.test_default_connection_thread_local",
-        "test_utils.tests.DisallowedDatabaseQueriesTests.test_disallowed_thread_database_connection",
         # Object of type ObjectId is not JSON serializable.
         "auth_tests.test_views.LoginTest.test_login_session_without_hash_session_key",
         # GenericRelation.value_to_string() assumes integer pk.
@@ -543,6 +542,19 @@ class DatabaseFeatures(BaseDatabaseFeatures):
             "custom_lookups.tests.LookupTests.test_custom_name_lookup",
             "custom_lookups.tests.LookupTests.test_div3_extract",
             "custom_lookups.tests.SubqueryTransformTests.test_subquery_usage",
+        },
+        "connection.close() does not close the connection.": {
+            "servers.test_liveserverthread.LiveServerThreadTest.test_closes_connections",
+            "servers.tests.LiveServerTestCloseConnectionTest.test_closes_connections",
+        },
+        "Disallowed query protection doesn't work on MongoDB.": {
+            # Because this backend doesn't use cursor(), chunked_cursor(), etc.
+            # https://github.com/django/django/blob/045110ff3089aefd9c3e65c707df465bacfed986/django/test/testcases.py#L195-L206
+            "test_utils.test_testcase.TestTestCase.test_disallowed_database_queries",
+            "test_utils.test_transactiontestcase.DisallowedDatabaseQueriesTests.test_disallowed_database_queries",
+            "test_utils.tests.DisallowedDatabaseQueriesTests.test_disallowed_database_chunked_cursor_queries",
+            "test_utils.tests.DisallowedDatabaseQueriesTests.test_disallowed_database_queries",
+            "test_utils.tests.DisallowedDatabaseQueriesTests.test_disallowed_thread_database_connection",
         },
     }
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -40,6 +40,7 @@ Models
 - :doc:`ref/models/querysets`
 - :doc:`ref/models/models`
 - :doc:`ref/models/indexes`
+- :doc:`ref/database`
 
 **Topic guides:**
 

--- a/docs/source/ref/database.rst
+++ b/docs/source/ref/database.rst
@@ -1,0 +1,43 @@
+==================
+Database reference
+==================
+
+This document supplements :doc:`Django's documentation on databases
+<django:ref/databases>`.
+
+Persistent connections
+======================
+
+Persistent connections avoid the overhead of reestablishing a connection to
+the database in each HTTP request. They're normally controlled by the
+:setting:`CONN_MAX_AGE` parameter which defines the maximum lifetime of a
+connection. However, this parameter is unnecessary and has no effect with
+Django MongoDB Backend because Django's API for connection-closing
+(``django.db.connection.close()``) has no effect. In other words, persistent
+connections are enabled by default.
+
+.. versionadded:: 5.2.0b0
+
+    Support for connection pooling was added.  In older versions, use
+    :setting:`CONN_MAX_AGE` to enable persistent connections.
+
+.. _connection-management:
+
+Connection management
+=====================
+
+Django uses this backend to open a connection pool to the database when it
+first makes a database query. It keeps this pool open and reuses it in
+subsequent requests.
+
+The underlying :class:`~pymongo.mongo_client.MongoClient` takes care connection
+management, so the :setting:`CONN_HEALTH_CHECKS` setting is unnecessary and has
+no effect.
+
+Django's API for connection-closing (``django.db.connection.close()``) has no
+effect. Rather, if you need to close the connection pool, use
+``django.db.connection.close_pool()``.
+
+.. versionadded:: 5.2.0b0
+
+    Support for connection pooling and ``connection.close_pool()`` were added.

--- a/docs/source/ref/index.rst
+++ b/docs/source/ref/index.rst
@@ -7,5 +7,6 @@ API reference
 
    models/index
    forms
+   database
    django-admin
    utils

--- a/docs/source/releases/5.2.x.rst
+++ b/docs/source/releases/5.2.x.rst
@@ -20,6 +20,8 @@ New features
 
 - Added :class:`.SearchIndex` and :class:`.VectorSearchIndex` for use on
   a model's :attr:`Meta.indexes <django.db.models.Options.indexes>`.
+- PyMongo's connection pooling is now used by default. See
+  :ref:`connection-management`.
 
 Backwards incompatible changes
 ------------------------------

--- a/tests/backend_/test_base.py
+++ b/tests/backend_/test_base.py
@@ -23,6 +23,19 @@ class DatabaseWrapperConnectionTests(TestCase):
         connection.set_autocommit(True)
         self.assertIs(connection.get_autocommit(), True)
 
+    def test_close(self):
+        """connection.close() doesn't close the connection."""
+        conn = connection.connection
+        self.assertIsNotNone(conn)
+        connection.close()
+        self.assertEqual(connection.connection, conn)
+
+    def test_close_pool(self):
+        """connection.close_pool() closes the connection."""
+        self.assertIsNotNone(connection.connection)
+        connection.close_pool()
+        self.assertIsNone(connection.connection)
+
     def test_connection_created_database_attr(self):
         """
         connection.database is available in the connection_created signal.
@@ -33,11 +46,11 @@ class DatabaseWrapperConnectionTests(TestCase):
             data["database"] = connection.database
 
         connection_created.connect(receiver)
-        connection.close()
+        connection.close_pool()
         # Accessing database implicitly connects.
         connection.database  # noqa: B018
         self.assertIs(data["database"], connection.database)
-        connection.close()
+        connection.close_pool()
         connection_created.disconnect(receiver)
         data.clear()
         connection.connect()


### PR DESCRIPTION
Some inspiration taken from [the implementation of PostgreSQL's connection pooling](https://github.com/django/django/commit/fad334e1a9b54ea1acb8cce02a25934c5acfe99f).