### PR TITLE
Fix indentation of EmbeddedModelField.embedded_model

### DIFF
--- a/docs/source/ref/models/fields.rst
+++ b/docs/source/ref/models/fields.rst
@@ -226,7 +226,7 @@ These indexes use 0-based indexing.
 
 Stores a model of type ``embedded_model``.
 
-   .. attribute:: embedded_model
+    .. attribute:: embedded_model
 
         This is a required argument.
 


### PR DESCRIPTION
I noticed that Sphinx references don't work correctly due to the missing space. :facepalm: 