### PR TITLE
INTPYTHON-355 Add transaction support

### DIFF
--- a/.github/workflows/test-python-atlas.yml
+++ b/.github/workflows/test-python-atlas.yml
@@ -53,4 +53,4 @@ jobs:
         working-directory: .
         run: bash .github/workflows/start_local_atlas.sh mongodb/mongodb-atlas-local:7
       - name: Run tests
-        run: python3 django_repo/tests/runtests_.py
+        run: python3 django_repo/tests/runtests.py --settings mongodb_settings -v 2

--- a/django_mongodb_backend/compiler.py
+++ b/django_mongodb_backend/compiler.py
@@ -685,7 +685,10 @@ class SQLInsertCompiler(SQLCompiler):
     @wrap_database_errors
     def insert(self, docs, returning_fields=None):
         """Store a list of documents using field columns as element names."""
-        inserted_ids = self.collection.insert_many(docs).inserted_ids
+        self.connection.validate_no_broken_transaction()
+        inserted_ids = self.collection.insert_many(
+            docs, session=self.connection.session
+        ).inserted_ids
         return [(x,) for x in inserted_ids] if returning_fields else []
 
     @cached_property
@@ -768,7 +771,10 @@ class SQLUpdateCompiler(compiler.SQLUpdateCompiler, SQLCompiler):
 
     @wrap_database_errors
     def update(self, criteria, pipeline):
-        return self.collection.update_many(criteria, pipeline).matched_count
+        self.connection.validate_no_broken_transaction()
+        return self.collection.update_many(
+            criteria, pipeline, session=self.connection.session
+        ).matched_count
 
     def check_query(self):
         super().check_query()

--- a/django_mongodb_backend/features.py
+++ b/django_mongodb_backend/features.py
@@ -533,8 +533,18 @@ class DatabaseFeatures(BaseDatabaseFeatures):
             "foreign_object.test_tuple_lookups.TupleLookupsTests",
         },
         "ColPairs is not supported.": {
-            # 'ColPairs' object has no attribute 'as_mql'
             "auth_tests.test_views.CustomUserCompositePrimaryKeyPasswordResetTest",
+            "composite_pk.test_aggregate.CompositePKAggregateTests",
+            "composite_pk.test_create.CompositePKCreateTests",
+            "composite_pk.test_delete.CompositePKDeleteTests",
+            "composite_pk.test_filter.CompositePKFilterTests",
+            "composite_pk.test_get.CompositePKGetTests",
+            "composite_pk.test_models.CompositePKModelsTests",
+            "composite_pk.test_order_by.CompositePKOrderByTests",
+            "composite_pk.test_update.CompositePKUpdateTests",
+            "composite_pk.test_values.CompositePKValuesTests",
+            "composite_pk.tests.CompositePKTests",
+            "composite_pk.tests.CompositePKFixturesTests",
         },
         "Custom lookups are not supported.": {
             "custom_lookups.tests.BilateralTransformTests",

--- a/django_mongodb_backend/features.py
+++ b/django_mongodb_backend/features.py
@@ -36,8 +36,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_temporal_subtraction = True
     # MongoDB stores datetimes in UTC.
     supports_timezones = False
-    # Not implemented: https://github.com/mongodb/django-mongodb-backend/issues/7
-    supports_transactions = False
     supports_unspecified_pk = True
     uses_savepoints = False
 
@@ -50,8 +48,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         "aggregation.tests.AggregateTestCase.test_order_by_aggregate_transform",
         # 'NulledTransform' object has no attribute 'as_mql'.
         "lookup.tests.LookupTests.test_exact_none_transform",
-        # "Save with update_fields did not affect any rows."
-        "basic.tests.SelectOnSaveTests.test_select_on_save_lying_update",
         # BaseExpression.convert_value() crashes with Decimal128.
         "aggregation.tests.AggregateTestCase.test_combine_different_types",
         "annotations.tests.NonAggregateAnnotationTestCase.test_combined_f_expression_annotation_with_aggregation",
@@ -96,6 +92,36 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         "expressions.tests.ExpressionOperatorTests.test_lefthand_bitwise_xor_right_null",
         "expressions.tests.ExpressionOperatorTests.test_lefthand_transformed_field_bitwise_or",
     }
+    _django_test_expected_failures_no_transactions = {
+        # "Save with update_fields did not affect any rows." instead of
+        # "An error occurred in the current transaction. You can't execute
+        # queries until the end of the 'atomic' block."
+        "basic.tests.SelectOnSaveTests.test_select_on_save_lying_update",
+    }
+    _django_test_expected_failures_transactions = {
+        # When update_or_create() fails with IntegrityError, the transaction
+        # is no longer usable.
+        "get_or_create.tests.UpdateOrCreateTests.test_manual_primary_key_test",
+        "get_or_create.tests.UpdateOrCreateTestsWithManualPKs.test_create_with_duplicate_primary_key",
+        # Tests that require savepoints
+        "admin_views.tests.AdminViewBasicTest.test_disallowed_to_field",
+        "admin_views.tests.AdminViewPermissionsTest.test_add_view",
+        "admin_views.tests.AdminViewPermissionsTest.test_change_view",
+        "admin_views.tests.AdminViewPermissionsTest.test_change_view_save_as_new",
+        "admin_views.tests.AdminViewPermissionsTest.test_delete_view",
+        "auth_tests.test_views.ChangelistTests.test_view_user_password_is_readonly",
+        "fixtures.tests.FixtureLoadingTests.test_loaddata_app_option",
+        "fixtures.tests.FixtureLoadingTests.test_unmatched_identifier_loading",
+        "fixtures_model_package.tests.FixtureTestCase.test_loaddata",
+        "get_or_create.tests.GetOrCreateTests.test_get_or_create_invalid_params",
+        "get_or_create.tests.UpdateOrCreateTests.test_integrity",
+        "many_to_many.tests.ManyToManyTests.test_add",
+        "many_to_one.tests.ManyToOneTests.test_fk_assignment_and_related_object_cache",
+        "model_fields.test_booleanfield.BooleanFieldTests.test_null_default",
+        "model_fields.test_floatfield.TestFloatField.test_float_validates_object",
+        "multiple_database.tests.QueryTestCase.test_generic_key_cross_database_protection",
+        "multiple_database.tests.QueryTestCase.test_m2m_cross_database_protection",
+    }
 
     @cached_property
     def django_test_expected_failures(self):
@@ -103,6 +129,10 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         expected_failures.update(self._django_test_expected_failures)
         if not self.is_mongodb_6_3:
             expected_failures.update(self._django_test_expected_failures_bitwise)
+        if self.supports_transactions:
+            expected_failures.update(self._django_test_expected_failures_transactions)
+        else:
+            expected_failures.update(self._django_test_expected_failures_no_transactions)
         return expected_failures
 
     django_test_skips = {
@@ -485,16 +515,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         "Connection health checks not implemented.": {
             "backends.base.test_base.ConnectionHealthChecksTests",
         },
-        "transaction.atomic() is not supported.": {
-            "backends.base.test_base.DatabaseWrapperLoggingTests",
-            "migrations.test_executor.ExecutorTests.test_atomic_operation_in_non_atomic_migration",
-            "migrations.test_operations.OperationTests.test_run_python_atomic",
-        },
-        "transaction.rollback() is not supported.": {
-            "transactions.tests.AtomicMiscTests.test_mark_for_rollback_on_error_in_autocommit",
-            "transactions.tests.AtomicMiscTests.test_mark_for_rollback_on_error_in_transaction",
-            "transactions.tests.NonAutocommitTests.test_orm_query_after_error_and_rollback",
-        },
         "migrate --fake-initial is not supported.": {
             "migrations.test_commands.MigrateTests.test_migrate_fake_initial",
             "migrations.test_commands.MigrateTests.test_migrate_fake_split_initial",
@@ -587,3 +607,20 @@ class DatabaseFeatures(BaseDatabaseFeatures):
             return False
         else:
             return True
+
+    @cached_property
+    def supports_select_union(self):
+        # Stage not supported inside of a multi-document transaction: $unionWith
+        return not self.supports_transactions
+
+    @cached_property
+    def supports_transactions(self):
+        """
+        Transactions are enabled if MongoDB is configured as a replica set or a
+        sharded cluster.
+        """
+        self.connection.ensure_connection()
+        client = self.connection.connection.admin
+        hello = client.command("hello")
+        # a replica set or a sharded cluster
+        return "setName" in hello or hello.get("msg") == "isdbgrid"

--- a/django_mongodb_backend/queryset.py
+++ b/django_mongodb_backend/queryset.py
@@ -35,7 +35,7 @@ class RawQuery(BaseRawQuery):
     def _execute_query(self):
         connection = connections[self.using]
         collection = connection.get_collection(self.model._meta.db_table)
-        self.cursor = collection.aggregate(self.pipeline)
+        self.cursor = collection.aggregate(self.pipeline, session=connection.session)
 
     def __str__(self):
         return str(self.pipeline)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -45,6 +45,7 @@ intersphinx_mapping = {
     "pymongo": ("https://pymongo.readthedocs.io/en/stable/", None),
     "python": ("https://docs.python.org/3/", None),
     "atlas": ("https://www.mongodb.com/docs/atlas/", None),
+    "manual": ("https://www.mongodb.com/docs/manual/", None),
 }
 
 root_doc = "contents"

--- a/docs/source/ref/database.rst
+++ b/docs/source/ref/database.rst
@@ -41,3 +41,43 @@ effect. Rather, if you need to close the connection pool, use
 .. versionadded:: 5.2.0b0
 
     Support for connection pooling and ``connection.close_pool()`` were added.
+
+.. _transactions:
+
+Transactions
+============
+
+.. versionadded:: 5.2.0b2
+
+Support for :doc:`Django's transactions APIs <django:topics/db/transactions>`
+is enabled if MongoDB is configured as a :doc:`replica set<manual:replication>`
+or a :doc:`sharded cluster <manual:sharding>`.
+
+If transactions aren't supported, query execution uses Django and MongoDB's
+default behavior of autocommit mode. Each query is immediately committed to the
+database. Django's transaction management APIs, such as
+:func:`~django.db.transaction.atomic`, function as no-ops.
+
+.. _transactions-limitations:
+
+Limitations
+-----------
+
+MongoDB's transaction limitations that are applicable to Django are:
+
+- :meth:`QuerySet.union() <django.db.models.query.QuerySet.union>` is not
+  supported inside a transaction.
+- If a transaction raises an exception, the transaction is no longer usable.
+  For example, if the update stage of :meth:`QuerySet.update_or_create()
+  <django.db.models.query.QuerySet.update_or_create>` fails with
+  :class:`~django.db.IntegrityError` due to a unique constraint violation, the
+  create stage won't be able to proceed.
+  :class:`pymongo.errors.OperationFailure` is raised, wrapped by
+  :class:`django.db.DatabaseError`.
+- Savepoints (i.e. nested :func:`~django.db.transaction.atomic` blocks) aren't
+  supported. The outermost :func:`~django.db.transaction.atomic` will start
+  a transaction while any subsequent :func:`~django.db.transaction.atomic`
+  blocks will have no effect.
+- Migration operations aren't :ref:`wrapped in a transaction
+  <topics/migrations:transactions>` because of MongoDB restrictions such as
+  adding indexes to existing collections while in a transaction.

--- a/docs/source/releases/5.2.x.rst
+++ b/docs/source/releases/5.2.x.rst
@@ -13,6 +13,7 @@ New features
 - Added subquery support for :class:`~.fields.EmbeddedModelArrayField`.
 - Added the ``options`` parameter to
   :func:`~django_mongodb_backend.utils.parse_uri`.
+- Added support for :ref:`database transactions <transactions>`.
 
 5.2.0 beta 1
 ============

--- a/docs/source/topics/known-issues.rst
+++ b/docs/source/topics/known-issues.rst
@@ -80,11 +80,7 @@ Database functions
 Transaction management
 ======================
 
-Query execution uses Django and MongoDB's default behavior of autocommit mode.
-Each query is immediately committed to the database.
-
-Django's :doc:`transaction management APIs <django:topics/db/transactions>`
-are not supported.
+See :ref:`transactions` for details.
 
 Database introspection
 ======================

--- a/tests/backend_/test_base.py
+++ b/tests/backend_/test_base.py
@@ -1,7 +1,7 @@
 from django.core.exceptions import ImproperlyConfigured
 from django.db import connection
 from django.db.backends.signals import connection_created
-from django.test import SimpleTestCase, TestCase
+from django.test import SimpleTestCase, TransactionTestCase
 
 from django_mongodb_backend.base import DatabaseWrapper
 
@@ -15,7 +15,9 @@ class DatabaseWrapperTests(SimpleTestCase):
             DatabaseWrapper(settings).get_connection_params()
 
 
-class DatabaseWrapperConnectionTests(TestCase):
+class DatabaseWrapperConnectionTests(TransactionTestCase):
+    available_apps = ["backend_"]
+
     def test_set_autocommit(self):
         self.assertIs(connection.get_autocommit(), True)
         connection.set_autocommit(False)

--- a/tests/backend_/test_features.py
+++ b/tests/backend_/test_features.py
@@ -1,0 +1,46 @@
+from unittest.mock import patch
+
+from django.db import connection
+from django.test import TestCase
+
+
+class SupportsTransactionsTests(TestCase):
+    def setUp(self):
+        # Clear the cached property.
+        del connection.features.supports_transactions
+
+    def tearDown(self):
+        del connection.features.supports_transactions
+
+    def test_replica_set(self):
+        """A replica set supports transactions."""
+
+        def mocked_command(command):
+            if command == "hello":
+                return {"setName": "foo"}
+            raise Exception("Unexpected command")
+
+        with patch("pymongo.synchronous.database.Database.command", wraps=mocked_command):
+            self.assertIs(connection.features.supports_transactions, True)
+
+    def test_sharded_cluster(self):
+        """A sharded cluster supports transactions."""
+
+        def mocked_command(command):
+            if command == "hello":
+                return {"msg": "isdbgrid"}
+            raise Exception("Unexpected command")
+
+        with patch("pymongo.synchronous.database.Database.command", wraps=mocked_command):
+            self.assertIs(connection.features.supports_transactions, True)
+
+    def test_no_support(self):
+        """No support on a non-replica set, non-sharded cluster."""
+
+        def mocked_command(command):
+            if command == "hello":
+                return {}
+            raise Exception("Unexpected command")
+
+        with patch("pymongo.synchronous.database.Database.command", wraps=mocked_command):
+            self.assertIs(connection.features.supports_transactions, False)

--- a/tests/queries_/test_objectid.py
+++ b/tests/queries_/test_objectid.py
@@ -1,6 +1,6 @@
 from bson import ObjectId
 from django.core.exceptions import ValidationError
-from django.test import TestCase
+from django.test import TestCase, skipUnlessDBFeature
 
 from .models import Order, OrderItem, Tag
 
@@ -75,6 +75,7 @@ class ObjectIdTests(TestCase):
         parent_qs = Tag.objects.filter(children__id__in=child_ids).distinct().order_by("name")
         self.assertSequenceEqual(parent_qs, [self.t1])
 
+    @skipUnlessDBFeature("supports_select_union")
     def test_filter_group_id_union_with_str(self):
         """Combine queries using union with string values."""
         qs_a = Tag.objects.filter(group_id=self.group_id_str_1)
@@ -82,6 +83,7 @@ class ObjectIdTests(TestCase):
         union_qs = qs_a.union(qs_b).order_by("name")
         self.assertSequenceEqual(union_qs, [self.t3, self.t4])
 
+    @skipUnlessDBFeature("supports_select_union")
     def test_filter_group_id_union_with_obj(self):
         """Combine queries using union with ObjectId values."""
         qs_a = Tag.objects.filter(group_id=self.group_id_obj_1)

--- a/tests/raw_query_/test_raw_aggregate.py
+++ b/tests/raw_query_/test_raw_aggregate.py
@@ -182,7 +182,8 @@ class RawAggregateTests(TestCase):
             {
                 field.name: getattr(author, field.name)
                 for field in reversed(Author._meta.concrete_fields)
-            }
+            },
+            session=connection.session,
         )
         query = []
         authors = Author.objects.all()


### PR DESCRIPTION
(initial comments at https://github.com/mongodb/django-mongodb-backend/pull/313)

The transactions tests are running via test-python-atlas.yml which uses https://hub.docker.com/r/mongodb/mongodb-atlas-local. I guess it uses a replica set.

Results from testing on a sharded cluster are in [my comment below](https://github.com/mongodb/django-mongodb-backend/pull/317#issuecomment-2988255234).

fixes #7 