### PR TITLE
INTPYTHON-527 Add queryable encryption support

### DIFF
--- a/django_mongodb_backend/__init__.py
+++ b/django_mongodb_backend/__init__.py
@@ -2,7 +2,7 @@ __version__ = "5.2.0b2.dev0"
 
 # Check Django compatibility before other imports which may fail if the
 # wrong version of Django is installed.
-from .utils import check_django_compatability, parse_uri
+from .utils import check_django_compatability, get_auto_encryption_options, parse_uri
 
 check_django_compatability()
 
@@ -15,7 +15,7 @@ from .indexes import register_indexes  # noqa: E402
 from .lookups import register_lookups  # noqa: E402
 from .query import register_nodes  # noqa: E402
 
-__all__ = ["parse_uri"]
+__all__ = ["get_auto_encryption_options", "parse_uri"]
 
 register_aggregates()
 register_checks()

--- a/django_mongodb_backend/features.py
+++ b/django_mongodb_backend/features.py
@@ -577,3 +577,13 @@ class DatabaseFeatures(BaseDatabaseFeatures):
             return False
         else:
             return True
+
+    @cached_property
+    def supports_queryable_encryption(self):
+        """
+        Queryable Encryption is supported if the server is Atlas or Enterprise.
+        """
+        self.connection.ensure_connection()
+        client = self.connection.connection.admin
+        build_info = client.command("buildInfo")
+        return "enterprise" in build_info.get("modules")

--- a/django_mongodb_backend/features.py
+++ b/django_mongodb_backend/features.py
@@ -581,9 +581,17 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     @cached_property
     def supports_queryable_encryption(self):
         """
-        Queryable Encryption is supported if the server is Atlas or Enterprise.
+        Queryable Encryption is supported if the server is Atlas or Enterprise
+        and if pymongocrypt is installed.
         """
         self.connection.ensure_connection()
         client = self.connection.connection.admin
         build_info = client.command("buildInfo")
-        return "enterprise" in build_info.get("modules")
+        is_enterprise = "enterprise" in build_info.get("modules")
+        try:
+            import pymongocrypt  # noqa: F401
+
+            has_pymongocrypt = True
+        except ImportError:
+            has_pymongocrypt = False
+        return is_enterprise and has_pymongocrypt

--- a/django_mongodb_backend/models.py
+++ b/django_mongodb_backend/models.py
@@ -14,3 +14,8 @@ class EmbeddedModel(models.Model):
 
     def save(self, *args, **kwargs):
         raise NotSupportedError("EmbeddedModels cannot be saved.")
+
+
+class EncryptedModel(models.Model):
+    class Meta:
+        abstract = True

--- a/django_mongodb_backend/utils.py
+++ b/django_mongodb_backend/utils.py
@@ -8,6 +8,7 @@ from django.db.backends.utils import logger
 from django.utils.functional import SimpleLazyObject
 from django.utils.text import format_lazy
 from django.utils.version import get_version_tuple
+from pymongo.encryption_options import AutoEncryptionOpts
 from pymongo.uri_parser import parse_uri as pymongo_parse_uri
 
 
@@ -33,11 +34,11 @@ def get_auto_encryption_options(crypt_shared_lib_path=None):
     key_vault_collection_name = "__keyVault"
     key_vault_namespace = f"{key_vault_database_name}.{key_vault_collection_name}"
     kms_providers = {}
-    return {
-        "kms_providers": kms_providers,
-        "key_vault_namespace": key_vault_namespace,
-        "crypt_shared_lib_path": crypt_shared_lib_path,
-    }
+    return AutoEncryptionOpts(
+        key_vault_namespace=key_vault_namespace,
+        kms_providers=kms_providers,
+        crypt_shared_lib_path=crypt_shared_lib_path,
+    )
 
 
 def parse_uri(uri, *, auto_encryption_options=None, db_name=None, test=None):
@@ -62,7 +63,7 @@ def parse_uri(uri, *, auto_encryption_options=None, db_name=None, test=None):
         raise ImproperlyConfigured("You must provide the db_name parameter.")
     options = uri.get("options")
     if auto_encryption_options:
-        options = {**uri.get("options"), **auto_encryption_options}
+        options = {**uri.get("options"), "auto_encryption_options": auto_encryption_options}
     settings_dict = {
         "ENGINE": "django_mongodb_backend",
         "NAME": db_name,

--- a/django_mongodb_backend/utils.py
+++ b/django_mongodb_backend/utils.py
@@ -8,6 +8,7 @@ from django.db.backends.utils import logger
 from django.utils.functional import SimpleLazyObject
 from django.utils.text import format_lazy
 from django.utils.version import get_version_tuple
+from pymongo.encryption_options import AutoEncryptionOpts
 from pymongo.uri_parser import parse_uri as pymongo_parse_uri
 
 
@@ -26,6 +27,16 @@ def check_django_compatability():
             f"You must use the latest version of django-mongodb-backend {A}.{B}.x "
             f"with Django {A}.{B}.y (found django-mongodb-backend {__version__})."
         )
+
+
+def get_auto_encryption_options(crypt_shared_lib_path=None):
+    key_vault_database_name = "encryption"
+    key_vault_collection_name = "__keyVault"
+    key_vault_namespace = f"{key_vault_database_name}.{key_vault_collection_name}"
+    kms_providers = {}
+    return AutoEncryptionOpts(
+        kms_providers, key_vault_namespace, crypt_shared_lib_path=crypt_shared_lib_path
+    )
 
 
 def parse_uri(uri, *, db_name=None, test=None):

--- a/django_mongodb_backend/utils.py
+++ b/django_mongodb_backend/utils.py
@@ -1,4 +1,5 @@
 import copy
+import os
 import time
 
 import django
@@ -33,7 +34,7 @@ def get_auto_encryption_options(crypt_shared_lib_path=None):
     key_vault_database_name = "encryption"
     key_vault_collection_name = "__keyVault"
     key_vault_namespace = f"{key_vault_database_name}.{key_vault_collection_name}"
-    kms_providers = {}
+    kms_providers = {"local": {"key": os.urandom(96)}}
     return AutoEncryptionOpts(
         key_vault_namespace=key_vault_namespace,
         kms_providers=kms_providers,

--- a/django_mongodb_backend/utils.py
+++ b/django_mongodb_backend/utils.py
@@ -8,7 +8,6 @@ from django.db.backends.utils import logger
 from django.utils.functional import SimpleLazyObject
 from django.utils.text import format_lazy
 from django.utils.version import get_version_tuple
-from pymongo.encryption_options import AutoEncryptionOpts
 from pymongo.uri_parser import parse_uri as pymongo_parse_uri
 
 
@@ -34,12 +33,14 @@ def get_auto_encryption_options(crypt_shared_lib_path=None):
     key_vault_collection_name = "__keyVault"
     key_vault_namespace = f"{key_vault_database_name}.{key_vault_collection_name}"
     kms_providers = {}
-    return AutoEncryptionOpts(
-        kms_providers, key_vault_namespace, crypt_shared_lib_path=crypt_shared_lib_path
-    )
+    return {
+        "kms_providers": kms_providers,
+        "key_vault_namespace": key_vault_namespace,
+        "crypt_shared_lib_path": crypt_shared_lib_path,
+    }
 
 
-def parse_uri(uri, *, db_name=None, test=None):
+def parse_uri(uri, *, auto_encryption_options=None, db_name=None, test=None):
     """
     Convert the given uri into a dictionary suitable for Django's DATABASES
     setting.
@@ -59,6 +60,9 @@ def parse_uri(uri, *, db_name=None, test=None):
     db_name = db_name or uri["database"]
     if not db_name:
         raise ImproperlyConfigured("You must provide the db_name parameter.")
+    options = uri.get("options")
+    if auto_encryption_options:
+        options = {**uri.get("options"), **auto_encryption_options}
     settings_dict = {
         "ENGINE": "django_mongodb_backend",
         "NAME": db_name,
@@ -66,7 +70,7 @@ def parse_uri(uri, *, db_name=None, test=None):
         "PORT": port,
         "USER": uri.get("username"),
         "PASSWORD": uri.get("password"),
-        "OPTIONS": uri.get("options"),
+        "OPTIONS": options,
     }
     if "authSource" not in settings_dict["OPTIONS"] and uri["database"]:
         settings_dict["OPTIONS"]["authSource"] = uri["database"]

--- a/tests/backend_/utils/test_parse_uri.py
+++ b/tests/backend_/utils/test_parse_uri.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 import pymongo
 from django.core.exceptions import ImproperlyConfigured
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, TestCase, skipUnlessDBFeature
 
 from django_mongodb_backend import get_auto_encryption_options, parse_uri
 
@@ -95,5 +95,10 @@ class ParseURITests(SimpleTestCase):
         with self.assertRaisesMessage(pymongo.errors.InvalidURI, "Invalid URI scheme"):
             parse_uri("cluster0.example.mongodb.net")
 
+
+# TODO: This can go in `test_features` once transaction support is added.
+class ParseUriOptionsTests(TestCase):
+    @skipUnlessDBFeature("supports_queryable_encryption")
     def test_queryable_encryption_config(self):
-        get_auto_encryption_options()
+        auto_encryption_options = get_auto_encryption_options()
+        self.assertEqual(auto_encryption_options._key_vault_namespace, "encryption.__keyVault")

--- a/tests/backend_/utils/test_parse_uri.py
+++ b/tests/backend_/utils/test_parse_uri.py
@@ -4,7 +4,7 @@ import pymongo
 from django.core.exceptions import ImproperlyConfigured
 from django.test import SimpleTestCase
 
-from django_mongodb_backend import parse_uri
+from django_mongodb_backend import get_auto_encryption_options, parse_uri
 
 
 class ParseURITests(SimpleTestCase):
@@ -94,3 +94,6 @@ class ParseURITests(SimpleTestCase):
     def test_no_scheme(self):
         with self.assertRaisesMessage(pymongo.errors.InvalidURI, "Invalid URI scheme"):
             parse_uri("cluster0.example.mongodb.net")
+
+    def test_queryable_encryption_config(self):
+        get_auto_encryption_options()

--- a/tests/backend_/utils/test_parse_uri.py
+++ b/tests/backend_/utils/test_parse_uri.py
@@ -96,9 +96,13 @@ class ParseURITests(SimpleTestCase):
             parse_uri("cluster0.example.mongodb.net")
 
 
-# TODO: This can go in `test_features` once transaction support is added.
+# TODO: This can be moved to `test_features` once transaction support is merged.
 class ParseUriOptionsTests(TestCase):
     @skipUnlessDBFeature("supports_queryable_encryption")
-    def test_queryable_encryption_config(self):
+    def test_auto_encryption_options(self):
         auto_encryption_options = get_auto_encryption_options()
-        self.assertEqual(auto_encryption_options._key_vault_namespace, "encryption.__keyVault")
+        settings_dict = parse_uri(
+            "mongodb://cluster0.example.mongodb.net/myDatabase",
+            auto_encryption_options=auto_encryption_options,
+        )
+        self.assertEqual(settings_dict["OPTIONS"]["key_vault_namespace"], "encryption.__keyVault")

--- a/tests/backend_/utils/test_parse_uri.py
+++ b/tests/backend_/utils/test_parse_uri.py
@@ -100,9 +100,5 @@ class ParseURITests(SimpleTestCase):
 class ParseUriOptionsTests(TestCase):
     @skipUnlessDBFeature("supports_queryable_encryption")
     def test_auto_encryption_options(self):
-        auto_encryption_options = get_auto_encryption_options()
-        settings_dict = parse_uri(
-            "mongodb://cluster0.example.mongodb.net/myDatabase",
-            auto_encryption_options=auto_encryption_options,
-        )
-        self.assertEqual(settings_dict["OPTIONS"]["key_vault_namespace"], "encryption.__keyVault")
+        auto_encryption_options = get_auto_encryption_options(crypt_shared_lib_path="/path/to/lib")
+        parse_uri("mongodb://localhost/db", auto_encryption_options=auto_encryption_options)

--- a/tests/model_fields_/models.py
+++ b/tests/model_fields_/models.py
@@ -8,7 +8,7 @@ from django_mongodb_backend.fields import (
     EmbeddedModelField,
     ObjectIdField,
 )
-from django_mongodb_backend.models import EmbeddedModel
+from django_mongodb_backend.models import EmbeddedModel, EncryptedModel
 
 
 # ObjectIdField
@@ -134,6 +134,10 @@ class Author(EmbeddedModel):
     age = models.IntegerField()
     address = EmbeddedModelField(Address)
     skills = ArrayField(models.CharField(max_length=100), null=True, blank=True)
+
+
+class EncryptedData(EncryptedModel):
+    pass
 
 
 class Book(models.Model):

--- a/tests/model_fields_/test_encrypted_model.py
+++ b/tests/model_fields_/test_encrypted_model.py
@@ -1,0 +1,8 @@
+from django.test import TestCase
+
+from .models import EncryptedData
+
+
+class ModelTests(TestCase):
+    def test_save_load(self):
+        EncryptedData.objects.create()


### PR DESCRIPTION
[Another](https://github.com/mongodb/django-mongodb-backend/pull/318) WIP
- Completed most setup in [qe.py](https://github.com/aclark4life/django-mongodb-cli/blob/3646c9feb74e65739f467c6c7e0795084ab60b5c/qe.py)
- Completed some setup in Django
  - Refactored `get_auto_encryption_options` to support ephemeral local KMS and allow `crypt_shared_lib_path` to be passed in
  - Add check for presence of libmongocrypt to `supports_queryable_encryption` feature check
- Started thinking about models, fields, migrations and planning an `issubclassof` check for `EncryptedModel` to call `create_encrypted_collection` instead of `create_collection` but need to pass `encrypted_client` to `ClientEncryption` somewhere in Django.

### TODO

- [ ] Decide on a configurable way to support local KMS so we can add other KMS later using the same configuration framework.
- [ ] Decide on how to configure `crypt_shared_lib_path`. I don't like setting an environment variable for this configuration task so I settled on passing to `get_auto_encryption_options` in the short term but maybe a Django setting or something else in long term.
- [ ] Decide on `EncryptedModel` and `EncryptedField` (not `EncryptedModelField` or EncryptedEmbeddedModelField yet!) implementation to support this:


```
from django_mongodb_backend.models import EncryptedModel
from django_mongodb_backend.models import EncryptedField
from django import models

class Person(EncryptedModel):
  ssn = EncryptedField(models.CharField)
```

### Question

Lastly, I'm not sure why PyMongo is trying to do explicit here or at least that is what it appears to be doing despite the auto config:

```
% j q
python qe.py
Traceback (most recent call last):
  File "/Users/alexclark/Developer/django-mongodb-cli/src/mongo-python-driver/pymongo/synchronous/encryption.py", line 124, in _wrap_encryption_errors
    yield
  File "/Users/alexclark/Developer/django-mongodb-cli/src/mongo-python-driver/pymongo/synchronous/encryption.py", line 861, in create_data_key
    self._encryption.create_data_key(
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        kms_provider,
        ^^^^^^^^^^^^^
    ...<2 lines>...
        key_material=key_material,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^
    ),
    ^
  File "/Users/alexclark/Developer/django-mongodb-cli/.venv/lib/python3.13/site-packages/pymongocrypt/synchronous/explicit_encrypter.py", line 66, in create_data_key
    with self.mongocrypt.data_key_context(kms_provider, opts) as ctx:
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
  File "/Users/alexclark/Developer/django-mongodb-cli/.venv/lib/python3.13/site-packages/pymongocrypt/mongocrypt.py", line 284, in data_key_context
    return DataKeyContext(
        self._create_context(),
    ...<3 lines>...
        self.__callback,
    )
  File "/Users/alexclark/Developer/django-mongodb-cli/.venv/lib/python3.13/site-packages/pymongocrypt/mongocrypt.py", line 560, in __init__
    raise ValueError(f"unknown kms_provider: {kms_provider}")
ValueError: unknown kms_provider: None

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/alexclark/Developer/django-mongodb-cli/src/mongo-python-driver/pymongo/synchronous/encryption.py", line 762, in create_encrypted_collection
    encrypted_fields["fields"][i]["keyId"] = self.create_data_key(
                                             ~~~~~~~~~~~~~~~~~~~~^
        kms_provider=kms_provider,  # type:ignore[arg-type]
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        master_key=master_key,
        ^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/Users/alexclark/Developer/django-mongodb-cli/src/mongo-python-driver/pymongo/synchronous/encryption.py", line 858, in create_data_key
    with _wrap_encryption_errors():
         ~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/Users/alexclark/.pyenv/versions/3.13.3/lib/python3.13/contextlib.py", line 162, in __exit__
    self.gen.throw(value)
    ~~~~~~~~~~~~~~^^^^^^^
  File "/Users/alexclark/Developer/django-mongodb-cli/src/mongo-python-driver/pymongo/synchronous/encryption.py", line 130, in _wrap_encryption_errors
    raise EncryptionError(exc) from exc
pymongo.errors.EncryptionError: unknown kms_provider: None

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/alexclark/Developer/django-mongodb-cli/qe.py", line 34, in <module>
    encrypted_collection = client_encryption.create_encrypted_collection(
        encrypted_database, "encrypted_collection", encrypted_fields
    )
  File "/Users/alexclark/Developer/django-mongodb-cli/src/mongo-python-driver/pymongo/synchronous/encryption.py", line 767, in create_encrypted_collection
    raise EncryptedCollectionError(exc, encrypted_fields) from exc
pymongo.errors.EncryptedCollectionError: unknown kms_provider: None
```

Seems like I may have missed passing `kms_providers` somewhere. 

I ruled out `crypted_shared_lib_path` being the cause. If you configure an invalid `/path/to/libmongocrypt.so` you get:

```
pymongocrypt.errors.MongoCryptError: A crypt_shared override path was specified [/path/to/libmongocrypt.so], but we failed to open a dynamic library at that location. Load error: [Error while opening candidate for crypt_shared dynamic library [/path/to/libmongocrypt.so]: dlopen(/path/to/libmongocrypt.so, 0x0005): tried: '/path/to/libmongocrypt.so' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/path/to/libmongocrypt.so' (no such file), '/path/to/libmongocrypt.so' (no such file)]


```

So… yeah.

