### PR TITLE
INTPYTHON-527 Add Queryable Encryption support

### DIFF
--- a/django_mongodb_backend/__init__.py
+++ b/django_mongodb_backend/__init__.py
@@ -2,7 +2,12 @@ __version__ = "5.2.0b2.dev0"
 
 # Check Django compatibility before other imports which may fail if the
 # wrong version of Django is installed.
-from .utils import check_django_compatability, get_auto_encryption_opts, parse_uri
+from .utils import (
+    check_django_compatability,
+    get_auto_encryption_opts,
+    get_kms_providers,
+    parse_uri,
+)
 
 check_django_compatability()
 
@@ -15,7 +20,7 @@ from .indexes import register_indexes  # noqa: E402
 from .lookups import register_lookups  # noqa: E402
 from .query import register_nodes  # noqa: E402
 
-__all__ = ["get_auto_encryption_opts", "parse_uri"]
+__all__ = ["get_auto_encryption_opts", "get_kms_providers", "parse_uri"]
 
 register_aggregates()
 register_checks()

--- a/django_mongodb_backend/__init__.py
+++ b/django_mongodb_backend/__init__.py
@@ -2,7 +2,7 @@ __version__ = "5.2.0b2.dev0"
 
 # Check Django compatibility before other imports which may fail if the
 # wrong version of Django is installed.
-from .utils import check_django_compatability, parse_uri
+from .utils import check_django_compatability, get_auto_encryption_opts, parse_uri
 
 check_django_compatability()
 
@@ -15,7 +15,7 @@ from .indexes import register_indexes  # noqa: E402
 from .lookups import register_lookups  # noqa: E402
 from .query import register_nodes  # noqa: E402
 
-__all__ = ["parse_uri"]
+__all__ = ["get_auto_encryption_opts", "parse_uri"]
 
 register_aggregates()
 register_checks()

--- a/django_mongodb_backend/utils.py
+++ b/django_mongodb_backend/utils.py
@@ -67,11 +67,13 @@ def get_customer_master_key():
 
 def get_kms_providers():
     """
-    Return the KMS providers for the MongoDB client.
+    Return supported KMS providers for MongoDB Client-Side Field Level Encryption.
     """
-    if not settings.KMS_PROVIDERS:
-        raise ImproperlyConfigured("You must set KMS_PROVIDERS in your Django settings.")
-    return settings.KMS_PROVIDERS
+    return {
+        "local": {
+            "key": get_customer_master_key(),
+        },
+    }
 
 
 def parse_uri(uri, *, db_name=None, test=None, options=None):

--- a/tests/backend_/utils/test_parse_uri.py
+++ b/tests/backend_/utils/test_parse_uri.py
@@ -4,7 +4,7 @@ import pymongo
 from django.core.exceptions import ImproperlyConfigured
 from django.test import SimpleTestCase
 
-from django_mongodb_backend import parse_uri
+from django_mongodb_backend import get_auto_encryption_opts, parse_uri
 
 
 class ParseURITests(SimpleTestCase):
@@ -94,3 +94,13 @@ class ParseURITests(SimpleTestCase):
     def test_no_scheme(self):
         with self.assertRaisesMessage(pymongo.errors.InvalidURI, "Invalid URI scheme"):
             parse_uri("cluster0.example.mongodb.net")
+
+    def test_options(self):
+        settings_dict = parse_uri(
+            "mongodb://cluster0.example.mongodb.net/myDatabase",
+            options={"auto_encryption_opts": get_auto_encryption_opts()},
+        )
+        self.assertIsInstance(
+            settings_dict["OPTIONS"]["auto_encryption_opts"],
+            pymongo.encryption_options.AutoEncryptionOpts,
+        )


### PR DESCRIPTION
[Another](https://github.com/mongodb/django-mongodb-backend/pull/319) WIP. [qe.py](https://github.com/mongodb-labs/django-mongodb-cli/blob/690a62ad2285b7f682f027e51984bf46a4e5079b/qe.py) updated too.

With this PR, Django claims it can't run non-encrypted commands, which means maybe we can't encrypt the entire connection …

```

(.venv) main ~/Developer/django-mongodb-cli> dm repo test django backend_    
Copying config/django/django_settings.py to src/django/tests/mongo_settings.py
Running ./runtests.py --settings mongo_settings --parallel 1 --verbosity 3 --debug-sql --noinput backend_
Testing against Django installed in '/Users/alexclark/Developer/django-mongodb-cli/src/django/django'
Importing application backend_
Found 20 test(s).
Creating test database for alias 'default' ('test_djangotests')...
Got an error creating the test database: command not supported for auto encryption: buildinfo
Destroying old test database for alias 'default' ('test_djangotests')...
Got an error recreating the test database: 'NoneType' object has no attribute 'execute'

```