### PR TITLE
INTPYTHON-676 Add optional signing of cache data

### DIFF
--- a/django_mongodb_backend/cache.py
+++ b/django_mongodb_backend/cache.py
@@ -21,16 +21,16 @@ class MongoSerializer:
         # Using type() rather than isinstance() matches only integers and not
         # subclasses like bool.
         if type(obj) is int:  # noqa: E721
-            return obj if self.signer is None else self.signer.sign(b64encode(obj))
+            return obj
         pickled_data = pickle.dumps(obj, protocol=self.protocol)  # noqa: S301
         return self.signer.sign(b64encode(pickled_data).decode()) if self.signer else pickled_data
 
     def loads(self, data):
-        if self.signer is not None:
-            data = b64decode(self.signer.unsign(data))
         try:
             return int(data)
         except (ValueError, TypeError):
+            if self.signer is not None:
+                data = b64decode(self.signer.unsign(data))
             return pickle.loads(data)  # noqa: S301
 
 

--- a/docs/source/topics/cache.rst
+++ b/docs/source/topics/cache.rst
@@ -32,6 +32,11 @@ In addition, the cache is culled based on ``CULL_FREQUENCY`` when  ``add()``
 or ``set()`` is called, if ``MAX_ENTRIES`` is exceeded. See
 :ref:`django:cache_arguments` for an explanation of these two options.
 
+Cache entries include a HMAC signature to ensure data integrity by default.
+You can disable this by setting ``ENABLE_SIGNING`` to ``False``. 
+Signatures can also include an optional salt parameter by setting ``SALT`` 
+to a string value.
+
 Creating the cache collection
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/cache_/tests.py
+++ b/tests/cache_/tests.py
@@ -97,6 +97,7 @@ def caches_setting_for_tests(base=None, exclude=None, **params):
         BACKEND="django_mongodb_backend.cache.MongoDBCache",
         # Spaces are used in the name to ensure quoting/escaping works.
         LOCATION="test cache collection",
+        ENABLE_SIGNING=False,
     ),
 )
 @modify_settings(
@@ -954,6 +955,22 @@ class CacheTests(TestCase):
         self.assertIsInstance(cache.serializer.dumps(True), bytes)
         self.assertIsInstance(cache.serializer.dumps("abc"), bytes)
 
+
+@override_settings(
+    CACHES=caches_setting_for_tests(
+        BACKEND="django_mongodb_backend.cache.MongoDBCache",
+        # Spaces are used in the name to ensure quoting/escaping works.
+        LOCATION="test cache collection",
+        ENABLE_SIGNING=True,
+        SALT="test-salt",
+    ),
+)
+class SignedCacheTests(CacheTests):
+    def test_serializer_dumps(self):
+        # The serializer should return a bytestring for signed caches.
+        self.assertEqual(cache.serializer.dumps(123), 123)
+        self.assertIsInstance(cache.serializer.dumps(True), str)
+        self.assertIsInstance(cache.serializer.dumps("abc"), str)
 
 class DBCacheRouter:
     """A router that puts the cache table on the 'other' database."""


### PR DESCRIPTION
Add HMAC signing of pickled cache data. This implementation uses [Django's built in HMAC signer](https://docs.djangoproject.com/en/5.2/topics/signing/) to avoid introducing new libraries. HMAC will introduce some overhead to performance, but for small and medium sized cache entries the impact should be minimal. The feature is easily disabled by setting `"ENABLE_SIGNING" = False` within the `CACHE` configuration.

Introduced two new cache config options:
- `ENABLE_SIGNING` - boolean value to turn HMAC signing on or off. Defaults to True (on)
- `SALT` - optional string to salt HMAC signatures with

