### PR TITLE
Make QuerySet.explain() return parsable JSON

### DIFF
--- a/django_mongodb_backend/compiler.py
+++ b/django_mongodb_backend/compiler.py
@@ -1,8 +1,7 @@
 import itertools
-import pprint
 from collections import defaultdict
 
-from bson import SON
+from bson import SON, json_util
 from django.core.exceptions import EmptyResultSet, FieldError, FullResultSet
 from django.db import IntegrityError, NotSupportedError
 from django.db.models import Count
@@ -652,12 +651,7 @@ class SQLCompiler(compiler.SQLCompiler):
             {"aggregate": self.collection_name, "pipeline": pipeline, "cursor": {}},
             **kwargs,
         )
-        # Generate the output: a list of lines that Django joins with newlines.
-        result = []
-        for key, value in explain.items():
-            formatted_value = pprint.pformat(value, indent=4)
-            result.append(f"{key}: {formatted_value}")
-        return result
+        return [json_util.dumps(explain, indent=4, ensure_ascii=False)]
 
 
 class SQLInsertCompiler(SQLCompiler):

--- a/docs/source/ref/models/querysets.rst
+++ b/docs/source/ref/models/querysets.rst
@@ -15,6 +15,8 @@ In addition, :meth:`QuerySet.delete() <django.db.models.query.QuerySet.delete>`
 and :meth:`update() <django.db.models.query.QuerySet.update>` do not support
 queries that span multiple collections.
 
+.. _queryset-explain:
+
 ``QuerySet.explain()``
 ======================
 
@@ -28,6 +30,24 @@ Example::
 
 Valid values for ``verbosity`` are ``"queryPlanner"`` (default),
 ``"executionStats"``, and ``"allPlansExecution"``.
+
+The result of ``explain()`` is a string::
+
+    >>> print(Model.objects.explain())
+    {
+        "explainVersion": "1",
+        "queryPlanner": {
+            ...
+        },
+        ...
+    }
+
+that can be parsed as JSON::
+
+    >>> from bson import json_util
+    >>> result = Model.objects.filter(name="MongoDB").explain()
+    >>> json_util.loads(result)['command']["pipeline"]
+    [{'$match': {'$expr': {'$eq': ['$name', 'MongoDB']}}}]
 
 MongoDB-specific ``QuerySet`` methods
 =====================================

--- a/docs/source/releases/5.2.x.rst
+++ b/docs/source/releases/5.2.x.rst
@@ -22,6 +22,8 @@ Bug fixes
 
 - Fixed ``RecursionError`` when using ``Trunc`` database functions on non-MongoDB
   databases.
+- :meth:`QuerySet.explain() <django.db.models.query.QuerySet.explain>` now
+  :ref:`returns a string that can be parsed as JSON <queryset-explain>`.
 
 5.2.0 beta 1
 ============

--- a/tests/queries_/test_explain.py
+++ b/tests/queries_/test_explain.py
@@ -1,0 +1,37 @@
+import json
+
+from bson import ObjectId, json_util
+from django.test import TestCase
+
+from .models import Author
+
+
+class ExplainTests(TestCase):
+    def test_idented(self):
+        """The JSON is dumped with indent=4."""
+        result = Author.objects.filter().explain()
+        self.assertEqual(result[:23], '{\n    "explainVersion":')
+
+    def test_object_id(self):
+        """
+        The json is dumped with bson.json_util() so that BSON types like ObjectID are
+        specially encoded.
+        """
+        id = ObjectId()
+        result = Author.objects.filter(id=id).explain()
+        parsed = json_util.loads(result)
+        self.assertEqual(
+            parsed["command"]["pipeline"], [{"$match": {"$expr": {"$eq": ["$_id", id]}}}]
+        )
+
+    def test_non_ascii(self):
+        """The json is dumped with ensure_ascii=False."""
+        name = "\U0001d120"
+        result = Author.objects.filter(name=name).explain()
+        # The non-decoded string must be checked since json.loads() unescapes
+        # non-ASCII characters.
+        self.assertIn(name, result)
+        parsed = json.loads(result)
+        self.assertEqual(
+            parsed["command"]["pipeline"], [{"$match": {"$expr": {"$eq": ["$name", name]}}}]
+        )


### PR DESCRIPTION
# Context
Calling `explain()` is extremely useful in debugging a MongoDB query. However, parsing the output of the `explain` call is a nightmare. This is because we take each line and format them using pprint to accommodate Django's native `explain` functionality, which joins all information line by line. 

# Solution
Rather than split key/values into multiple lines, we should just dump the json as one string blob in the list. This way `.explain` can easily leverage `json.load` or `json_util.load`.

- [x] Confirm the fix
- [x] Create a test_explain test case
- [x] Update the changelog

# Changes in this PR
* import PyMongo library `json_util`
* call `json_util.dumps(..., indent=4)` and return that in a list of length 1.

# Change
## Before
```python
>>> exp = Author.objects.filter().explain()
>>> json.loads(exp)
Traceback (most recent call last):
  File "<console>", line 1, in <module>
...
               ^^^^^^^^^^^^^^^^^^^^^^
json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 1 column 2 (char 1)
```

## After
<img width="900" height="1131" alt="image" src="https://github.com/user-attachments/assets/e764f8dc-8117-4911-8e22-7ff0e3687b8e" />