### PR TITLE
INTPYTHON-676: Adding security and optimization to cache collections

### DIFF
--- a/docs/source/topics/cache.rst
+++ b/docs/source/topics/cache.rst
@@ -32,6 +32,23 @@ In addition, the cache is culled based on ``CULL_FREQUENCY`` when  ``add()``
 or ``set()`` is called, if ``MAX_ENTRIES`` is exceeded. See
 :ref:`django:cache_arguments` for an explanation of these two options.
 
+Cache entries include a HMAC signature to ensure data integrity by default.
+You can disable this by setting ``ENABLE_SIGNING`` to ``False``.  
+Signatures can also include an optional key and salt parameter by setting 
+``KEY`` and ``SALT`` repectively. Signatures are provided by the Blake2 hash
+function, making Key sizes limited to 64 bytes, and salt sizes limited to 16 
+bytes. If a key is not provided, cache entries will be signed using the 
+``SECRET_KEY``.
+
+    CACHES = {
+        "default": {
+            "BACKEND": "django_mongodb_backend.cache.MongoDBCache",
+            "LOCATION": "my_cache_collection",
+            "KEY": "my_secret_key",
+            "SALT": "my_salt",
+        },
+    }
+
 Creating the cache collection
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Add HMAC signing of pickled cache data. This implementation uses [Blake2b](https://docs.python.org/3/library/hashlib.html#hashlib.blake2b) from hashlib to avoid introducing new 3rd party dependencies. 

HMAC introduces some overhead to performance, but for cache entries less then 32kb the impact is less then 100ns. For cache entries larger then 1MB, signing can introduce up to 2ms of latency. For BSON serializable types (`int`, `str`, `bytes`), pickling and signing are skipped, and the values are stored in the cache collection directly.

The feature is easily disabled by setting "ENABLE_SIGNING" = False within the CACHE configuration.

Introduced three new cache config options:
 - ENABLE_SIGNING - boolean value to turn HMAC signing on or off. Defaults to True (on)
 - SALT - optional 16 character string to salt HMAC signatures with
 - KEY - optional string to use when performing HMAC operations. This can be up to 64 charcers, and if not provided, SECRET_KEY is used instead.
 
 If the cache fails to validate a signature `SuspiciousOperation` will be thrown. 