### PR TITLE
Prohibit deactivating transaction management with AUTOCOMMIT=False in DATABASES

### DIFF
--- a/django_mongodb_backend/base.py
+++ b/django_mongodb_backend/base.py
@@ -159,6 +159,11 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         super().__init__(settings_dict, alias=alias)
         self.session = None
 
+    def check_settings(self):
+        super().check_settings()
+        if not self.settings_dict["AUTOCOMMIT"]:
+            raise ImproperlyConfigured("MongoDB does not support AUTOCOMMIT=False.")
+
     def get_collection(self, name, **kwargs):
         collection = Collection(self.database, name, **kwargs)
         if self.queries_logged:

--- a/docs/source/ref/database.rst
+++ b/docs/source/ref/database.rst
@@ -58,6 +58,10 @@ default behavior of autocommit mode. Each query is immediately committed to the
 database. Django's transaction management APIs, such as
 :func:`~django.db.transaction.atomic`, function as no-ops.
 
+:ref:`Deactivating transaction management <django:deactivate-transaction-management>`
+by setting :setting:`AUTOCOMMIT <DATABASE-AUTOCOMMIT>` to ``False`` in the
+:setting:`DATABASES` setting isn't supported.
+
 .. _transactions-limitations:
 
 Limitations

--- a/tests/backend_/test_base.py
+++ b/tests/backend_/test_base.py
@@ -1,3 +1,5 @@
+import copy
+
 from django.core.exceptions import ImproperlyConfigured
 from django.db import connection
 from django.db.backends.signals import connection_created
@@ -13,6 +15,14 @@ class DatabaseWrapperTests(SimpleTestCase):
         msg = 'settings.DATABASES is missing the "NAME" value.'
         with self.assertRaisesMessage(ImproperlyConfigured, msg):
             DatabaseWrapper(settings).get_connection_params()
+
+    def test_autocommit_false(self):
+        new_connection = connection.copy()
+        new_connection.settings_dict = copy.deepcopy(connection.settings_dict)
+        new_connection.settings_dict["AUTOCOMMIT"] = False
+        msg = "MongoDB does not support AUTOCOMMIT=False."
+        with self.assertRaisesMessage(ImproperlyConfigured, msg):
+            new_connection.check_settings()
 
 
 class DatabaseWrapperConnectionTests(TransactionTestCase):


### PR DESCRIPTION
Unlike SQL databases, MongoDB has no notion of "deactivating transaction management". A side effect of this backend's implementation is that this configuration starts a transaction upon connecting to the database.