### PR TITLE
[PoC] Push simple filter conditions into $lookup stage.

### DIFF
--- a/django_mongodb_backend/query.py
+++ b/django_mongodb_backend/query.py
@@ -132,7 +132,7 @@ def extra_where(self, compiler, connection):  # noqa: ARG001
 def join(self, compiler, connection, pushed_expressions=None):
     def _get_reroot_replacements(expressions):
         if not expressions:
-            return []
+            return None
         columns = []
         for expr in expressions:
             # Determine whether the column needs to be transformed or rerouted
@@ -152,7 +152,9 @@ def join(self, compiler, connection, pushed_expressions=None):
         # based on their rerouted positions in the join pipeline.
         replacements = {}
         for col, parent_pos in columns:
-            column_target = Col(compiler.collection_name, col.target, col.output_field)
+            target = col.target.clone()
+            target.remote_field = col.target.remote_field
+            column_target = Col(compiler.collection_name, target)
             if parent_pos is not None:
                 target_col = f"${parent_template}{parent_pos}"
                 column_target.target.db_column = target_col

--- a/tests/queries_/test_mql.py
+++ b/tests/queries_/test_mql.py
@@ -20,7 +20,8 @@ class MQLTests(TestCase):
             "{'$lookup': {'from': 'queries__author', "
             "'let': {'parent__field__0': '$author_id'}, "
             "'pipeline': [{'$match': {'$expr': "
-            "{'$and': [{'$eq': ['$$parent__field__0', '$_id']}]}}}], 'as': 'queries__author'}}, "
+            "{'$and': [{'$eq': ['$$parent__field__0', '$_id']}, "
+            "{'$eq': ['$name', 'Bob']}]}}}], 'as': 'queries__author'}}, "
             "{'$unwind': '$queries__author'}, "
             "{'$match': {'$expr': {'$eq': ['$queries__author.name', 'Bob']}}}])",
         )


### PR DESCRIPTION
In this PR we tackle the slow join pushing the simple conditions inside the $lookup. the condition is also fix a bug.

New query:
```python
[{'$lookup': {'as': 'm2m_regress_selfrefer_references',
              'from': 'm2m_regress_selfrefer_references',
              'let': {'parent__field__0': '$_id'},
              'pipeline': [{'$match': {'$expr': {'$and': [{'$eq': ['$$parent__field__0',
                                                                   '$to_selfrefer_id']},
                                                          {'$eq': ['$from_selfrefer_id',
                                                                   ObjectId('687ad601daccf7b757ff46ec')]}]}}}]}},
 {'$unwind': '$m2m_regress_selfrefer_references'},
 {'$match': {'$expr': {'$eq': ['$m2m_regress_selfrefer_references.from_selfrefer_id',
                               ObjectId('687ad601daccf7b757ff46ec')]}}}]
```

Previous query

```python
[{'$lookup': {'as': 'm2m_regress_selfrefer_references',
              'from': 'm2m_regress_selfrefer_references',
              'let': {'parent__field__0': '$_id'},
              'pipeline': [{'$match': {'$expr': {'$and': [{'$eq': ['$$parent__field__0',
                                                                   '$to_selfrefer_id']}]}}}]}},
 {'$unwind': '$m2m_regress_selfrefer_references'},
 {'$match': {'$expr': {'$eq': ['$m2m_regress_selfrefer_references.from_selfrefer_id',
                               ObjectId('687ad676396a5de149f2ea4d')]}}}]
```