### PR TITLE
Improve QuerySet performance by removing limit on server-side chunking

### DIFF
--- a/django_mongodb_backend/compiler.py
+++ b/django_mongodb_backend/compiler.py
@@ -258,7 +258,6 @@ class SQLCompiler(compiler.SQLCompiler):
             else:
                 return self._make_result(obj, self.columns)
         # result_type is MULTI
-        cursor.batch_size(chunk_size)
         result = self.cursor_iter(cursor, chunk_size, self.columns)
         if not chunked_fetch:
             # If using non-chunked reads, read data into memory.

--- a/docs/source/releases/5.1.x.rst
+++ b/docs/source/releases/5.1.x.rst
@@ -11,6 +11,7 @@ Django MongoDB Backend 5.1.x
   the ``base_field`` uses a database converter.
 - Fixed ``RecursionError`` when using ``Trunc`` database functions on non-MongoDB
   databases.
+- Improved ``QuerySet`` performance by removing low limit on server-side chunking.
 
 5.1.0 beta 3
 ============

--- a/docs/source/releases/5.2.x.rst
+++ b/docs/source/releases/5.2.x.rst
@@ -25,6 +25,7 @@ Bug fixes
   databases.
 - :meth:`QuerySet.explain() <django.db.models.query.QuerySet.explain>` now
   :ref:`returns a string that can be parsed as JSON <queryset-explain>`.
+- Improved ``QuerySet`` performance by removing low limit on server-side chunking.
 
 5.2.0 beta 1
 ============


### PR DESCRIPTION
# Summary
We noticed large dips in performance when attempting to retrieve multiple documents (n > 10_000) for any query. Digging into our logic, we found from setting our `cursor.batch_size(100)` which would limit database fetches to retrieve _at most_ 100 documents. In cases of 10_000+ documents to fetch, that would generate 100 individual queries to the database. 

**We do not need to configure batch sizing** as PyMongo already handles its own performant chunking policy via the cursor iterator. This PR removes any batching on the iterator and prevents end-user configuration of batch sizing. This significantly reduces the number of requests and leaves it to the server to determine how many documents to return.

# Changes in this PR
* Removed GET_ITERATOR_CHUNK_SIZE import and usage from the SQL compiler
* yield the `_make_result` output of a "row" (document) from the cursor object.
* Updated documentation to reflect the change in cursor iteration behavior

# Screenshots
```python
>>> def timer(func, *args, **kwargs):  
...      """Time a function call and return (result, execution_time in SECONDS)"""  
...      start = time.perf_counter()  
...      result = func(*args, **kwargs)  
...      end = time.perf_counter()  
...      exec_time = end - start  
...      return result, exec_time  
... 
```
## Before
```python
>>> timer(lambda: Author.objects.filter())
(<MongoQuerySet [<Author: >, *REMOVED FOR EASY READING*, '...(remaining elements truncated)...']>, 0.0006403750012395903)
>>> timer(lambda: list(Author.objects.filter()[:101])[0])
(<Author: Author object (6877c9c7d04f764442793292)>, 0.04128820799815003)
>>> timer(lambda: list(Author.objects.filter()[:10_001])[0])
(<Author: Author object (6877c9c7d04f764442793292)>, 1.9592289169959258)
>>> timer(lambda: list(Author.objects.filter()[:100_001])[0])
(<Author: Author object (6877c9c7d04f764442793292)>, 20.37065891599923)
>>> timer(lambda: list(Author.objects.filter()[:1_000_001])[0])
(<Author: Author object (6877c9c7d04f764442793292)>, 20.618212166999)

# JOIN LOGIC
>>> timer(lambda: list(Author.objects.filter(address__city="London")[:1_000_001])[0])
(<Author: Author object (6877c9c7d04f764442793292)>, 34.79546758400102)
```

## After 
```python

>>> import time
>>> timer(lambda: Author.objects.filter())
(<MongoQuerySet [<Author: >, *REMOVED FOR EASY READING* '...(remaining elements truncated)...']>, 0.0009210830030497164)
>>> timer(lambda: list(Author.objects.filter()[:101])[0])
(<Author: Author object (6877c9c7d04f764442793292)>, 0.04708974999812199)
>>> timer(lambda: list(Author.objects.filter()[:10_001])[0])
(<Author: Author object (6877c9c7d04f764442793292)>, 0.23040095800388372)
>>> timer(lambda: list(Author.objects.filter()[:100_001])[0])
(<Author: Author object (6877c9c7d04f764442793292)>, 1.136685874997056)
>>> timer(lambda: list(Author.objects.filter()[:1_000_001])[0])
(<Author: Author object (6877c9c7d04f764442793292)>, 1.4290711669964367)
>>> 

# JOIN LOGIC
>>> timer(lambda: list(Author.objects.filter(address__city="London")[:1_000_001])[0])
(<Author: Author object (6877c9c7d04f764442793292)>, 14.903681124997092)
```
