### PR TITLE
Update release dates for 5.2.0b2 and 5.1.0b4

### DIFF
--- a/docs/source/releases/5.1.x.rst
+++ b/docs/source/releases/5.1.x.rst
@@ -5,7 +5,7 @@ Django MongoDB Backend 5.1.x
 5.1.0 beta 4
 ============
 
-*August 12, 2025*
+*August 13, 2025*
 
 - Backward-incompatible: Removed support for database caching as the MongoDB security
   team considers the cache backend's ``pickle`` encoding of cached values a

--- a/docs/source/releases/5.2.x.rst
+++ b/docs/source/releases/5.2.x.rst
@@ -5,7 +5,7 @@ Django MongoDB Backend 5.2.x
 5.2.0 beta 2
 ============
 
-*August 12, 2025*
+*August 13, 2025*
 
 New features
 ------------


### PR DESCRIPTION
Hadn't pushed release yesterday; date needs to reflect the release date push. 