### PR TITLE
Remove usage of isinstance() with unioned types

### DIFF
--- a/django_mongodb_backend/compiler.py
+++ b/django_mongodb_backend/compiler.py
@@ -669,7 +669,7 @@ class SQLCompiler(compiler.SQLCompiler):
             if (
                 isinstance(expr, Lookup)
                 and isinstance(expr.lhs, Col)
-                and (is_direct_value(expr.rhs) or isinstance(expr.rhs, Value | Col))
+                and (is_direct_value(expr.rhs) or isinstance(expr.rhs, (Value, Col)))
             ):
                 pushed_filters[expr.lhs.alias].append(expr)
         for alias in tuple(self.query.alias_map):

--- a/django_mongodb_backend/expressions/builtins.py
+++ b/django_mongodb_backend/expressions/builtins.py
@@ -187,7 +187,7 @@ def when(self, compiler, connection):
 
 def value(self, compiler, connection):  # noqa: ARG001
     value = self.value
-    if isinstance(value, list | int):
+    if isinstance(value, (list, int)):
         # Wrap lists & numbers in $literal to prevent ambiguity when Value
         # appears in $project.
         return {"$literal": value}

--- a/django_mongodb_backend/expressions/search.py
+++ b/django_mongodb_backend/expressions/search.py
@@ -42,11 +42,11 @@ class Operator:
 
 class SearchCombinable:
     def _combine(self, other, connector):
-        if not isinstance(self, CompoundExpression | CombinedSearchExpression):
+        if not isinstance(self, (CompoundExpression, CombinedSearchExpression)):
             lhs = CompoundExpression(must=[self])
         else:
             lhs = self
-        if other and not isinstance(other, CompoundExpression | CombinedSearchExpression):
+        if other and not isinstance(other, (CompoundExpression, CombinedSearchExpression)):
             rhs = CompoundExpression(must=[other])
         else:
             rhs = other

--- a/django_mongodb_backend/fields/array.py
+++ b/django_mongodb_backend/fields/array.py
@@ -63,7 +63,7 @@ class ArrayField(CheckFieldDefaultMixin, Field):
 
     @classmethod
     def _choices_is_value(cls, value):
-        return isinstance(value, list | tuple) or super()._choices_is_value(value)
+        return isinstance(value, (list, tuple)) or super()._choices_is_value(value)
 
     def check(self, **kwargs):
         errors = super().check(**kwargs)
@@ -126,7 +126,7 @@ class ArrayField(CheckFieldDefaultMixin, Field):
         return "array"
 
     def get_db_prep_value(self, value, connection, prepared=False):
-        if isinstance(value, list | tuple):
+        if isinstance(value, (list, tuple)):
             return [self.base_field.get_db_prep_value(i, connection, prepared=False) for i in value]
         return value
 
@@ -236,7 +236,7 @@ class Array(Func):
 
 class ArrayRHSMixin:
     def __init__(self, lhs, rhs):
-        if isinstance(rhs, tuple | list):
+        if isinstance(rhs, (tuple, list)):
             expressions = []
             for value in rhs:
                 if not hasattr(value, "resolve_expression"):

--- a/django_mongodb_backend/fields/embedded_model_array.py
+++ b/django_mongodb_backend/fields/embedded_model_array.py
@@ -39,7 +39,7 @@ class EmbeddedModelArrayField(ArrayField):
         return name, path, args, kwargs
 
     def get_db_prep_value(self, value, connection, prepared=False):
-        if isinstance(value, list | tuple):
+        if isinstance(value, (list, tuple)):
             # Must call get_db_prep_save() rather than get_db_prep_value()
             # to transform model instances to dicts.
             return [self.base_field.get_db_prep_save(i, connection) for i in value]

--- a/django_mongodb_backend/fields/json.py
+++ b/django_mongodb_backend/fields/json.py
@@ -65,7 +65,7 @@ def has_key_lookup(self, compiler, connection):
     """Return MQL to check for the existence of a key."""
     rhs = self.rhs
     lhs = process_lhs(self, compiler, connection)
-    if not isinstance(rhs, list | tuple):
+    if not isinstance(rhs, (list, tuple)):
         rhs = [rhs]
     paths = []
     # Transform any "raw" keys into KeyTransforms to allow consistent handling

--- a/django_mongodb_backend/fields/polymorphic_embedded_model_array.py
+++ b/django_mongodb_backend/fields/polymorphic_embedded_model_array.py
@@ -43,7 +43,7 @@ class PolymorphicEmbeddedModelArrayField(ArrayField):
         return name, path, args, kwargs
 
     def get_db_prep_value(self, value, connection, prepared=False):
-        if isinstance(value, list | tuple):
+        if isinstance(value, (list, tuple)):
             # Must call get_db_prep_save() rather than get_db_prep_value()
             # to transform model instances to dicts.
             return [self.base_field.get_db_prep_save(i, connection) for i in value]

--- a/django_mongodb_backend/indexes.py
+++ b/django_mongodb_backend/indexes.py
@@ -170,7 +170,7 @@ class VectorSearchIndex(SearchIndex):
     def __init__(self, *, fields=(), name=None, similarities):
         super().__init__(fields=fields, name=name)
         self.similarities = similarities
-        self._multiple_similarities = isinstance(similarities, tuple | list)
+        self._multiple_similarities = isinstance(similarities, (tuple, list))
         for func in similarities if self._multiple_similarities else (similarities,):
             if func not in self.VALID_SIMILARITIES:
                 raise ValueError(
@@ -200,7 +200,7 @@ class VectorSearchIndex(SearchIndex):
                             id=f"{self._error_id_prefix}.E002",
                         )
                     )
-                if not isinstance(field.base_field, FloatField | IntegerField):
+                if not isinstance(field.base_field, (FloatField, IntegerField)):
                     errors.append(
                         Error(
                             "VectorSearchIndex requires the base field of "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ ignore = [
   "S101",   # Use of `assert` detected
   "RUF012", # Mutable class attributes should be annotated with `typing.ClassVar`
   "PLW2901", # `for` loop variable `value` overwritten by assignment target
+  "UP038",  # non-pep604-isinstance is deprecated
 ]
 unfixable = []
 exclude = []

--- a/tests/atlas_search_/test_search.py
+++ b/tests/atlas_search_/test_search.py
@@ -48,7 +48,7 @@ def _delayed_assertion(timeout: float = 4, interval: float = 0.5):
         @wraps(assert_func)
         def wrapper(self, fetch, *args, **kwargs):
             start = monotonic()
-            if not isinstance(fetch, Callable | QuerySet):
+            if not isinstance(fetch, (Callable, QuerySet)):
                 raise ValueError(
                     "The first argument to a delayed assertion must be a QuerySet or a callable "
                     "that returns the value to be asserted."


### PR DESCRIPTION
Ruff's [UP038](https://docs.astral.sh/ruff/rules/non-pep604-isinstance/) that enforced this is deprecated because it's slower.