### PR TITLE
Fix EmbeddedModelField crash when retrieving model where field name isn't present in db data

### DIFF
--- a/django_mongodb_backend/operations.py
+++ b/django_mongodb_backend/operations.py
@@ -184,6 +184,8 @@ class DatabaseOperations(GISOperations, BaseDatabaseOperations):
         if value is not None:
             # Apply database converters to each field of the embedded model.
             for field in expression.output_field.embedded_model._meta.fields:
+                if field.blank:
+                    continue
                 field_expr = Expression(output_field=field)
                 converters = connection.ops.get_db_converters(
                     field_expr


### PR DESCRIPTION
If the field is embedded and empty, it gave an error about the absence of this field.