### PR TITLE
INTPYTHON-772 Fix transaction.atomic() crash if connection isn't initialized

### DIFF
--- a/django_mongodb_backend/base.py
+++ b/django_mongodb_backend/base.py
@@ -272,6 +272,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
     @async_unsafe
     def start_transaction_mongo(self):
         if self.session is None:
+            self.ensure_connection()
             self.session = self.connection.start_session()
             with debug_transaction(self, "session.start_transaction()"):
                 self.session.start_transaction()

--- a/docs/releases/5.2.x.rst
+++ b/docs/releases/5.2.x.rst
@@ -23,6 +23,8 @@ Bug fixes
   :attr:`~django.db.models.Field.db_column`.
 - Corrected the search index type of ``EmbeddedModelField`` and
   ``PolymorphicEmbeddedModelField`` from ``embeddedDocuments`` to ``document``.
+- Fixed ``transaction.atomic()`` crash if the database connection isn't
+  initialized.
 
 Deprecated features
 -------------------

--- a/tests/transactions_/tests.py
+++ b/tests/transactions_/tests.py
@@ -1,4 +1,4 @@
-from django.db import DatabaseError
+from django.db import DatabaseError, connection
 from django.test import TransactionTestCase, skipIfDBFeature, skipUnlessDBFeature
 
 from django_mongodb_backend import transaction
@@ -139,6 +139,12 @@ class AtomicTests(TransactionTestCase):
                 pass
 
         transaction.atomic(Callable())  # Must not raise an exception
+
+    def test_initializes_connection(self):
+        """transaction.atomic() opens the connection if needed."""
+        connection.close_pool()
+        with transaction.atomic():
+            pass
 
 
 @skipIfDBFeature("_supports_transactions")


### PR DESCRIPTION
I ran into a problem during a transaction when I call the POST create method in the view and try to create documents through the serializer:

```
class CreateTariff(TariffsSerializer):
    @transaction.atomic(using="mongodb")
    def create(self, validated_data):
        ...
```
This error occurs spontaneously and always at the first call to the endpoints API. 

```
File: C\test\venv\lib\site-packages\rest_framework\views.py in dispatch (line 506)
response = handler(request, *args, **kwargs)

File: C:\test\venv\lib\site-packages\rest_framework\mixins.py in create (line 19)
self.perform_create(serializer)

File: C:\test\venv\lib\site-packages\rest_framework\mixins.py in perform_create (line 24)
serializer.save()

File: C:\test\venv\lib\site-packages\rest_framework\serializers.py in save (line 208)
self.instance = self.create(validated_data)

...

File: C:\test\venv\lib\site-packages\django_mongodb_backend\transaction.py in __enter__ (line 29)
connection.start_transaction_mongo()

File: C:\test\venv\lib\site-packages\django\utils\asyncio.py in inner (line 26)
return func(*args, **kwargs)

File: C:\test\venv\lib\site-packages\django_mongodb_backend\base.py in start_transaction_mongo (line 275)
self.session = self.connection.start_session()
Error: 'NoneType' object has no attribute 'start_session'
```

As I understand it, it occurs due to the fact that the connection lazily creates a connection (connection.connection) during the entry into the transaction.
