### PR TITLE
INTPYTHON-778 Correct Polymorphic/EmbeddedModelField search index type

### DIFF
--- a/django_mongodb_backend/fields/embedded_model.py
+++ b/django_mongodb_backend/fields/embedded_model.py
@@ -23,7 +23,7 @@ class EmbeddedModelField(models.Field):
         super().__init__(*args, **kwargs)
 
     def db_type(self, connection):
-        return "embeddedDocuments"
+        return "object"
 
     def check(self, **kwargs):
         from ..models import EmbeddedModel  # noqa: PLC0415

--- a/django_mongodb_backend/fields/polymorphic_embedded_model.py
+++ b/django_mongodb_backend/fields/polymorphic_embedded_model.py
@@ -25,7 +25,7 @@ class PolymorphicEmbeddedModelField(models.Field):
         super().__init__(*args, **kwargs)
 
     def db_type(self, connection):
-        return "embeddedDocuments"
+        return "object"
 
     def check(self, **kwargs):
         from ..models import EmbeddedModel  # noqa: PLC0415

--- a/docs/releases/5.2.x.rst
+++ b/docs/releases/5.2.x.rst
@@ -21,6 +21,8 @@ Bug fixes
   ``EmbeddedModel``).
 - Made ``EmbeddedModel`` fields respect
   :attr:`~django.db.models.Field.db_column`.
+- Corrected the search index type of ``EmbeddedModelField`` and
+  ``PolymorphicEmbeddedModelField`` from ``embeddedDocuments`` to ``document``.
 
 Deprecated features
 -------------------

--- a/tests/indexes_/test_search_indexes.py
+++ b/tests/indexes_/test_search_indexes.py
@@ -159,7 +159,7 @@ class SearchIndexSchemaTests(SchemaAssertionMixin, TestCase):
                         "type": "string",
                     },
                     "datetime": {"type": "date"},
-                    "embedded_model": {"dynamic": False, "fields": {}, "type": "embeddedDocuments"},
+                    "embedded_model": {"dynamic": False, "fields": {}, "type": "document"},
                     "float": {
                         "indexDoubles": True,
                         "indexIntegers": True,

--- a/tests/model_fields_/test_embedded_model.py
+++ b/tests/model_fields_/test_embedded_model.py
@@ -30,6 +30,9 @@ from .utils import truncate_ms
 
 
 class MethodTests(SimpleTestCase):
+    def test_db_type(self):
+        self.assertEqual(EmbeddedModelField("Data").db_type(connection), "object")
+
     def test_deconstruct(self):
         field = EmbeddedModelField("Data", null=True)
         field.name = "field_name"

--- a/tests/model_fields_/test_polymorphic_embedded_model.py
+++ b/tests/model_fields_/test_polymorphic_embedded_model.py
@@ -18,6 +18,9 @@ class MethodTests(SimpleTestCase):
         field = PolymorphicEmbeddedModelField(["Data"], null=True)
         self.assertIs(field.editable, False)
 
+    def test_db_type(self):
+        self.assertEqual(PolymorphicEmbeddedModelField(["Data"]).db_type(connection), "object")
+
     def test_deconstruct(self):
         field = PolymorphicEmbeddedModelField(["Data"], null=True)
         field.name = "field_name"


### PR DESCRIPTION
"embeddedDocuments" isn't a BSON type.