### PR TITLE
INTPYTHON-994 Make QuerySet.exclude() omit documents with absent JSONField keys

### DIFF
--- a/django_mongodb_backend/features.py
+++ b/django_mongodb_backend/features.py
@@ -60,12 +60,6 @@ class DatabaseFeatures(GISFeatures, BaseDatabaseFeatures):
         # by Value(None, JSONField())) and a SQL null (queried using the
         # isnull lookup). Both of these queries return both nulls.
         "model_fields.test_jsonfield.TestSaveLoad.test_json_null_different_from_sql_null",
-        # Using JSONField keys in QuerySet.exclude() incorrectly treats
-        # documents with absent keys as satisfying the exclusion:
-        # https://jira.mongodb.org/browse/INTPYTHON-994.
-        "model_fields.test_jsonfield.TestQuerying.test_lookup_exclude",
-        "model_fields.test_jsonfield.TestQuerying.test_lookup_exclude_nonexistent_key",
-        "model_fields.test_jsonfield.TestQuerying.test_none_key_exclude",
         # $concat only supports strings, not int
         "db_functions.text.test_concat.ConcatTests.test_concat_non_str",
         # QuerySet.order_by() with annotation transform doesn't work:

--- a/django_mongodb_backend/fields/json.py
+++ b/django_mongodb_backend/fields/json.py
@@ -15,6 +15,7 @@ from django.db.models.fields.json import (
     KeyTransformIn,
     KeyTransformIsNull,
     KeyTransformNumericLookupMixin,
+    KeyTransformTextLookupMixin,
 )
 
 from django_mongodb_backend.lookups import builtin_lookup_expr, builtin_lookup_path
@@ -157,6 +158,38 @@ def key_transform_exact_path(self, compiler, connection):
     }
 
 
+def key_transform_negated(self, compiler, connection, as_expr=False):
+    """
+    Return MQL for NOT(<JSONField key lookup>) using SQL three-valued
+    semantics: a row matches only when the key exists and the positive lookup
+    is false. A missing key makes the comparison NULL in SQL (and NULL is not
+    true), so such rows must be excluded from the negated result; MongoDB's
+    $not/$nor alone would instead treat a missing key as satisfying the
+    negation and wrongly include those rows. None of the positive key lookups
+    match a missing key, so ANDing the key-existence check with the negated
+    positive MQL yields the correct result. Whole-field null handling is
+    contributed separately by the IsNull term Django adds to negated lookups.
+    """
+    if not as_expr and getattr(self, "can_use_path", False):
+        lhs_mql = process_lhs(self, compiler, connection)
+        positive = self.as_mql(compiler, connection)
+        return {"$and": [_has_key_predicate(lhs_mql, None), {"$nor": [positive]}]}
+    lhs_mql = process_lhs(self, compiler, connection, as_expr=True)
+    # Traverse to the root column for the null check in _has_key_predicate().
+    previous = self.lhs
+    while isinstance(previous, KeyTransform):
+        previous = previous.lhs
+    root_column = previous.as_mql(compiler, connection, as_expr=True)
+    positive = self.as_mql(compiler, connection, as_expr=True)
+    expr = {
+        "$and": [
+            _has_key_predicate(lhs_mql, root_column, as_expr=True),
+            {"$not": [positive]},
+        ]
+    }
+    return expr if as_expr else {"$expr": expr}
+
+
 def key_transform_in_expr(self, compiler, connection):
     """
     Return MQL to check if a JSON path exists and that its values are in the
@@ -232,3 +265,8 @@ def register_json_field():
     KeyTransformIsNull.as_mql_expr = key_transform_is_null_expr
     KeyTransformIsNull.as_mql_path = key_transform_is_null_path
     KeyTransformNumericLookupMixin.as_mql_expr = key_transform_numeric_lookup_mixin_expr
+    # SQL three-valued negation for all comparison lookups on a JSON key.
+    KeyTransformExact.as_mql_negated = key_transform_negated
+    KeyTransformIn.as_mql_negated = key_transform_negated
+    KeyTransformNumericLookupMixin.as_mql_negated = key_transform_negated
+    KeyTransformTextLookupMixin.as_mql_negated = key_transform_negated

--- a/django_mongodb_backend/query.py
+++ b/django_mongodb_backend/query.py
@@ -361,7 +361,63 @@ def join(self, compiler, connection, pushed_filter_expression=None):
     return lookup_pipeline
 
 
+def _has_custom_negation(node):
+    """
+    Return whether the subtree contains a lookup with custom negation MQL.
+    """
+    return any(
+        _has_custom_negation(child)
+        if isinstance(child, WhereNode)
+        else hasattr(child, "as_mql_negated")
+        for child in node.children
+    )
+
+
+def _negate(node, compiler, connection, as_expr):
+    """
+    Return MQL for NOT(node), pushing the negation down to the leaves (De
+    Morgan's laws). This lets lookups that require SQL three-valued semantics
+    (e.g. JSON key transforms) provide their own correct negation instead of
+    relying on $nor/$not, which mishandle missing values.
+    """
+    if not isinstance(node, WhereNode):
+        negate = getattr(node, "as_mql_negated", None)
+        if negate is not None:
+            return negate(compiler, connection, as_expr=as_expr)
+        try:
+            mql = node.as_mql(compiler, connection, as_expr=as_expr)
+        except EmptyResultSet as exc:
+            raise FullResultSet from exc
+        except FullResultSet as exc:
+            raise EmptyResultSet from exc
+        return {"$not": [mql]} if as_expr else {"$nor": [mql]}
+    if node.negated:
+        # NOT(NOT(group)) == group; compile the group without negation.
+        node = node.__class__(node.children, node.connector)
+        return node.as_mql(compiler, connection, as_expr=as_expr)
+    operator = "$or" if node.connector == AND else "$and"
+    parts = []
+    for child in node.children:
+        try:
+            parts.append(_negate(child, compiler, connection, as_expr))
+        except FullResultSet:
+            if operator == "$or":
+                raise  # OR with an always-true term = always-true.
+            # AND with an always-true term: skip it.
+        except EmptyResultSet:
+            if operator == "$and":
+                raise  # AND with a never-true term = never-true.
+            # OR with a never-true term: skip it.
+    if not parts:
+        raise EmptyResultSet if operator == "$or" else FullResultSet
+    return parts[0] if len(parts) == 1 else {operator: parts}
+
+
 def where_node(self, compiler, connection, as_expr=False):
+    if self.negated and self.connector in (AND, OR) and _has_custom_negation(self):
+        # Negate a copy without the flag so _negate() applies De Morgan's laws.
+        positive = self.__class__(self.children, self.connector)
+        return _negate(positive, compiler, connection, as_expr)
     if self.connector == AND:
         full_needed, empty_needed = len(self.children), 1
     else:

--- a/docs/releases/6.0.x.rst
+++ b/docs/releases/6.0.x.rst
@@ -67,6 +67,10 @@ Bug fixes
   :lookup:`iendswith`, :lookup:`contains`, :lookup:`icontains`,
   :lookup:`regex`, and :lookup:`iregex`) on non-string fields.
 
+- Fixed ``QuerySet.exclude()`` (and negated ``Q`` objects) on
+  :class:`~django.db.models.JSONField` key lookups so that documents which
+  don't contain the key are no longer included in the results.
+
 - Fixed form rendering of
   :class:`~django_mongodb_backend.fields.EmbeddedModelField`
   and :class:`~django_mongodb_backend.fields.EmbeddedModelArrayField` so that

--- a/docs/topics/known-issues.rst
+++ b/docs/topics/known-issues.rst
@@ -50,13 +50,10 @@ Querying
   :meth:`~django.db.models.query.QuerySet.update` do not support queries that
   span multiple collections.
 
-- When querying :class:`~django.db.models.JSONField`:
-
-  - There is no way to distinguish between a JSON ``"null"`` (represented by
-    ``Value(None, JSONField())``) and a SQL ``null`` (queried using the
-    :lookup:`isnull` lookup). Both of these queries return both of these nulls.
-  - Using JSON keys in ``QuerySet.exclude()`` incorrectly treats objects with
-    absent keys as satisfying the exclusion.
+- When querying :class:`~django.db.models.JSONField` there is no way to
+  distinguish between a JSON ``"null"`` (represented by
+  ``Value(None, JSONField())``) and a SQL ``null`` (queried using the
+  :lookup:`isnull` lookup). Both of these queries return both of these nulls.
 
 Database functions
 ==================


### PR DESCRIPTION
`exclude(value__key=X)` and negated Q objects on `JSONField` key lookups wrongly returned documents that don't contain the key. SQL databases treat the comparison on a missing key as `NULL` (three-valued logic), so `NOT(...)` excludes those rows; MongoDB's `$nor`/`$not` instead treat a missing key as "not equal" and included them.

Give `KeyTransformExact` a custom negation (key exists AND value != RHS), and push negation down to the leaves via De Morgan's laws in `where_node()` when a subtree contains such a lookup, so each lookup can supply its own SQL-correct negation while other lookups keep using `$nor`/`$not`.