### PR TITLE
INTPYTHON-796 Add support for embedded model field in migrations

### DIFF
--- a/django_mongodb_backend/db/migrations/autodetector.py
+++ b/django_mongodb_backend/db/migrations/autodetector.py
@@ -12,6 +12,7 @@ from django_mongodb_backend.db.migrations.operations import (
     RemoveEmbeddedField,
     RenameEmbeddedField,
 )
+from django_mongodb_backend.fields import EmbeddedModelArrayField
 from django_mongodb_backend.indexes import FieldColumn
 
 _MISSING = object()
@@ -23,6 +24,9 @@ class MigrationAutodetector(BaseMigrationAutodetector):
 
         def get_old_embedded_paths(field, name_prefix=None, path_prefix=None):
             if hasattr(field, "embedded_model"):
+                if isinstance(field, EmbeddedModelArrayField):
+                    # EmbeddedModelArrayField isn't yet supported.
+                    return
                 if isinstance(field.embedded_model, str):
                     model_label = field.embedded_model
                 else:
@@ -61,6 +65,9 @@ class MigrationAutodetector(BaseMigrationAutodetector):
 
         def get_new_embedded_paths(field, name_prefix=None, path_prefix=None):
             if hasattr(field, "embedded_model"):
+                if isinstance(field, EmbeddedModelArrayField):
+                    # EmbeddedModelArrayField isn't yet supported.
+                    return
                 embedded_model = self.to_state.models[tuple(field.embedded_model.split("."))]
                 for subfield_name, subfield in embedded_model.fields.items():
                     subfield_column = subfield.get_attname_column()[1]

--- a/django_mongodb_backend/db/migrations/autodetector.py
+++ b/django_mongodb_backend/db/migrations/autodetector.py
@@ -4,6 +4,7 @@ from django.core.exceptions import FieldDoesNotExist
 from django.db import models
 from django.db.migrations.autodetector import MigrationAutodetector as BaseMigrationAutodetector
 from django.db.migrations.autodetector import OperationDependency
+from django.db.migrations.operations import AddField as DjangoAddField
 
 from django_mongodb_backend.db.migrations.operations import (
     AddEmbeddedField,
@@ -12,6 +13,8 @@ from django_mongodb_backend.db.migrations.operations import (
     RenameEmbeddedField,
 )
 from django_mongodb_backend.indexes import FieldColumn
+
+_MISSING = object()
 
 
 class MigrationAutodetector(BaseMigrationAutodetector):
@@ -138,7 +141,12 @@ class MigrationAutodetector(BaseMigrationAutodetector):
         )
         if not preserve_default:
             field = field.clone()
-            if isinstance(field, time_fields) and field.auto_now_add:
+            default = self._get_add_field_default(app_label, model_name, field_name)
+            if default is not _MISSING:
+                # Reuse the default from the corresponding AddField operation
+                # to avoid prompting the user twice for the same field.
+                field.default = default
+            elif isinstance(field, time_fields) and field.auto_now_add:
                 field.default = self.questioner.ask_auto_now_add_addition(field_name, model_name)
             else:
                 field.default = self.questioner.ask_not_null_addition(field_name, model_name)
@@ -154,6 +162,33 @@ class MigrationAutodetector(BaseMigrationAutodetector):
             ),
             dependencies=dependencies,
         )
+
+    def _get_add_field_default(self, app_label, model_name, field_name):
+        """
+        Return the default from the AddField operation for the leaf field of
+        field_name, to avoid prompting the user twice for the same field.
+        Return _MISSING if no matching AddField operation is found.
+        """
+        *parents, leaf_field_name = field_name.split(".")
+        leaf_app_label = app_label
+        leaf_model_name = model_name
+        for part in parents:
+            parent_field = self.to_state.models[leaf_app_label, leaf_model_name].get_field(part)
+            if hasattr(parent_field, "embedded_model"):
+                label_parts = parent_field.embedded_model.split(".")
+                if len(label_parts) == 2:
+                    leaf_app_label, leaf_model_name = label_parts
+                else:
+                    leaf_model_name = label_parts[0]
+        for op in self.generated_operations.get(leaf_app_label, []):
+            if (
+                isinstance(op, DjangoAddField)
+                and op.model_name == leaf_model_name
+                and op.name == leaf_field_name
+                and not op.preserve_default
+            ):
+                return op.field.default
+        return _MISSING
 
     def generate_renamed_embedded_fields(self):
         """

--- a/django_mongodb_backend/db/migrations/autodetector.py
+++ b/django_mongodb_backend/db/migrations/autodetector.py
@@ -24,9 +24,6 @@ class MigrationAutodetector(BaseMigrationAutodetector):
 
         def get_old_embedded_paths(field, name_prefix=None, path_prefix=None):
             if hasattr(field, "embedded_model"):
-                if isinstance(field, EmbeddedModelArrayField):
-                    # EmbeddedModelArrayField isn't yet supported.
-                    return
                 if isinstance(field.embedded_model, str):
                     model_label = field.embedded_model
                 else:
@@ -36,6 +33,7 @@ class MigrationAutodetector(BaseMigrationAutodetector):
                     app_label,
                     self.renamed_models.get(model_lookup, model_lookup[1]),
                 ]
+                is_array = isinstance(field, EmbeddedModelArrayField)
                 for subfield_name, subfield in embedded_model.fields.items():
                     if name_prefix:
                         name = f"{name_prefix}.{subfield_name}"
@@ -46,7 +44,10 @@ class MigrationAutodetector(BaseMigrationAutodetector):
                         path = f"{path_prefix}.{subfield_column}"
                     else:
                         field_column = field.get_attname_column()[1]
-                        path = f"{field_column}.{subfield_column}"
+                        if is_array:
+                            path = f"{field_column}.$[].{subfield_column}"
+                        else:
+                            path = f"{field_column}.{subfield_column}"
                     self.old_embedded_field_keys[(app_label, model_name, name)] = path
                     # Check for nested embeds.
                     get_old_embedded_paths(subfield, name, path)
@@ -65,10 +66,8 @@ class MigrationAutodetector(BaseMigrationAutodetector):
 
         def get_new_embedded_paths(field, name_prefix=None, path_prefix=None):
             if hasattr(field, "embedded_model"):
-                if isinstance(field, EmbeddedModelArrayField):
-                    # EmbeddedModelArrayField isn't yet supported.
-                    return
                 embedded_model = self.to_state.models[tuple(field.embedded_model.split("."))]
+                is_array = isinstance(field, EmbeddedModelArrayField)
                 for subfield_name, subfield in embedded_model.fields.items():
                     subfield_column = subfield.get_attname_column()[1]
                     if name_prefix:
@@ -79,7 +78,10 @@ class MigrationAutodetector(BaseMigrationAutodetector):
                         path = f"{path_prefix}.{subfield_column}"
                     else:
                         field_column = field.get_attname_column()[1]
-                        path = f"{field_column}.{subfield_column}"
+                        if is_array:
+                            path = f"{field_column}.$[].{subfield_column}"
+                        else:
+                            path = f"{field_column}.{subfield_column}"
                     self.new_embedded_field_keys[(app_label, model_name, name)] = path
                     get_new_embedded_paths(subfield, name, path)
 

--- a/django_mongodb_backend/db/migrations/autodetector.py
+++ b/django_mongodb_backend/db/migrations/autodetector.py
@@ -1,7 +1,85 @@
+import contextlib
+
+from django.core.exceptions import FieldDoesNotExist
+from django.db import models
 from django.db.migrations.autodetector import MigrationAutodetector as BaseMigrationAutodetector
+from django.db.migrations.autodetector import OperationDependency
+
+from django_mongodb_backend.db.migrations.operations import (
+    AddEmbeddedField,
+    AlterEmbeddedField,
+    RemoveEmbeddedField,
+    RenameEmbeddedField,
+)
+from django_mongodb_backend.indexes import FieldColumn
 
 
 class MigrationAutodetector(BaseMigrationAutodetector):
+    def _prepare_field_lists(self):
+        super()._prepare_field_lists()
+
+        def get_old_embedded_paths(field, name_prefix=None, path_prefix=None):
+            if hasattr(field, "embedded_model"):
+                if isinstance(field.embedded_model, str):
+                    model_label = field.embedded_model
+                else:
+                    model_label = field.embedded_model._meta.label_lower
+                model_lookup = tuple(model_label.split("."))
+                embedded_model = self.from_state.models[
+                    app_label,
+                    self.renamed_models.get(model_lookup, model_lookup[1]),
+                ]
+                for subfield_name, subfield in embedded_model.fields.items():
+                    if name_prefix:
+                        name = f"{name_prefix}.{subfield_name}"
+                    else:
+                        name = f"{field.name}.{subfield_name}"
+                    subfield_column = subfield.get_attname_column()[1]
+                    if path_prefix:
+                        path = f"{path_prefix}.{subfield_column}"
+                    else:
+                        field_column = field.get_attname_column()[1]
+                        path = f"{field_column}.{subfield_column}"
+                    self.old_embedded_field_keys[(app_label, model_name, name)] = path
+                    # Check for nested embeds.
+                    get_old_embedded_paths(subfield, name, path)
+
+        self.old_embedded_field_keys = {}
+        for app_label, model_name in self.kept_model_keys:
+            for _field_name, field in self.from_state.models[
+                app_label, self.renamed_models.get((app_label, model_name), model_name)
+            ].fields.items():
+                try:
+                    if not self.to_state.models[app_label, model_name].options.get("managed", True):
+                        continue
+                except KeyError:
+                    continue
+                get_old_embedded_paths(field)
+
+        def get_new_embedded_paths(field, name_prefix=None, path_prefix=None):
+            if hasattr(field, "embedded_model"):
+                embedded_model = self.to_state.models[tuple(field.embedded_model.split("."))]
+                for subfield_name, subfield in embedded_model.fields.items():
+                    subfield_column = subfield.get_attname_column()[1]
+                    if name_prefix:
+                        name = f"{name_prefix}.{subfield_name}"
+                    else:
+                        name = f"{field.name}.{subfield_name}"
+                    if path_prefix:
+                        path = f"{path_prefix}.{subfield_column}"
+                    else:
+                        field_column = field.get_attname_column()[1]
+                        path = f"{field_column}.{subfield_column}"
+                    self.new_embedded_field_keys[(app_label, model_name, name)] = path
+                    get_new_embedded_paths(subfield, name, path)
+
+        self.new_embedded_field_keys = {}
+        for app_label, model_name in self.kept_model_keys:
+            for _field_name, field in self.to_state.models[app_label, model_name].fields.items():
+                if not self.to_state.models[app_label, model_name].options.get("managed", True):
+                    continue
+                get_new_embedded_paths(field)
+
     def generate_renamed_models(self):
         # Treat unmanaged models like managed models so that all migration
         # operations are generated for them, not just CreateModel/DeleteModel.
@@ -11,3 +89,230 @@ class MigrationAutodetector(BaseMigrationAutodetector):
         self.new_model_keys |= self.new_unmanaged_keys
         self.new_unmanaged_keys = set()
         super().generate_renamed_models()
+
+    def generate_removed_fields(self):
+        super().generate_removed_fields()
+        self.generate_renamed_embedded_fields()
+        self.generate_removed_embedded_fields()
+
+    def generate_altered_db_table(self):
+        super().generate_altered_db_table()
+        self.generate_added_embedded_fields()
+        self.generate_altered_embedded_fields()
+
+    def generate_added_embedded_fields(self):
+        """Make AddEmbeddedField operations."""
+        for app_label, model_name, field_name in sorted(
+            set(self.new_embedded_field_keys) - set(self.old_embedded_field_keys)
+        ):
+            # If the embedded field was just added, then there's no need to
+            # add each subfield.
+            if "." in field_name:
+                parent_field_name = field_name.rsplit(".", 1)[0]
+                if (
+                    app_label,
+                    model_name,
+                    parent_field_name,
+                ) not in self.old_field_keys and (
+                    app_label,
+                    model_name,
+                    parent_field_name,
+                ) not in self.old_embedded_field_keys:
+                    continue
+            self._generate_added_embedded_field(app_label, model_name, field_name)
+
+    def _generate_added_embedded_field(self, app_label, model_name, field_name):
+        field = self.get_field(self.to_state.models[app_label, model_name], field_name)
+        # Adding a field always depends at least on its removal.
+        dependencies = [
+            OperationDependency(app_label, model_name, field_name, OperationDependency.Type.REMOVE)
+        ]
+        # You can't just add NOT NULL fields with no default or fields
+        # which don't allow empty strings as default.
+        time_fields = (models.DateField, models.DateTimeField, models.TimeField)
+        preserve_default = (
+            field.null
+            or field.has_default()
+            or (field.blank and field.empty_strings_allowed)
+            or (isinstance(field, time_fields) and field.auto_now)
+        )
+        if not preserve_default:
+            field = field.clone()
+            if isinstance(field, time_fields) and field.auto_now_add:
+                field.default = self.questioner.ask_auto_now_add_addition(field_name, model_name)
+            else:
+                field.default = self.questioner.ask_not_null_addition(field_name, model_name)
+        if field.unique and field.has_default() and callable(field.default):
+            self.questioner.ask_unique_callable_default_addition(field_name, model_name)
+        self.add_operation(
+            app_label,
+            AddEmbeddedField(
+                model_name=model_name,
+                name=self.new_embedded_field_keys[app_label, model_name, field_name],
+                field=field,
+                preserve_default=preserve_default,
+            ),
+            dependencies=dependencies,
+        )
+
+    def generate_renamed_embedded_fields(self):
+        """
+        Make RenameEmbeddedField operations for renamed embedded leaf fields.
+        """
+        # Build inverse of renamed_fields: (app_label, model_name, old_name) ->
+        # new_name.
+        renamed_field_inverse = {
+            (al, mn, old): new for (al, mn, new), old in self.renamed_fields.items()
+        }
+        for app_label, model_name, old_attr_path in sorted(
+            set(self.old_embedded_field_keys) - set(self.new_embedded_field_keys)
+        ):
+            *parents, leaf_field_name = old_attr_path.split(".")
+            # Navigate the from_state to find the model containing the leaf
+            # field.
+            current_app_label = app_label
+            current_model_name = model_name
+            for part in parents:
+                field = self.from_state.models[current_app_label, current_model_name].get_field(
+                    part
+                )
+                if hasattr(field, "embedded_model"):
+                    label_parts = field.embedded_model.split(".")
+                    if len(label_parts) == 2:
+                        current_app_label, current_model_name = label_parts
+                    else:
+                        current_model_name = label_parts[0]
+            # Check if the leaf field was renamed.
+            new_leaf_field_name = renamed_field_inverse.get(
+                (current_app_label, current_model_name, leaf_field_name)
+            )
+            if new_leaf_field_name is None:
+                continue
+            new_attr_path = ".".join([*parents, new_leaf_field_name])
+            if (app_label, model_name, new_attr_path) not in self.new_embedded_field_keys:
+                continue
+            self._generate_renamed_embedded_field(
+                app_label,
+                model_name,
+                old_attr_path,
+                new_attr_path,
+                current_app_label,
+                current_model_name,
+                new_leaf_field_name,
+            )
+            # Remove from both dicts so remove/add generators skip these paths.
+            del self.old_embedded_field_keys[app_label, model_name, old_attr_path]
+            del self.new_embedded_field_keys[app_label, model_name, new_attr_path]
+
+    def _generate_renamed_embedded_field(
+        self,
+        app_label,
+        model_name,
+        old_attr_path,
+        new_attr_path,
+        leaf_app_label,
+        leaf_model_name,
+        leaf_new_field_name,
+    ):
+        self.add_operation(
+            app_label,
+            RenameEmbeddedField(
+                model_name=model_name,
+                old_name=old_attr_path,
+                new_name=new_attr_path,
+            ),
+        )
+
+    def generate_removed_embedded_fields(self):
+        """Make RemoveEmbeddedField operations."""
+        for app_label, model_name, field_name in sorted(
+            set(self.old_embedded_field_keys) - set(self.new_embedded_field_keys)
+        ):
+            self._generate_removed_embedded_field(app_label, model_name, field_name)
+
+    def _generate_removed_embedded_field(self, app_label, model_name, field_name):
+        self.add_operation(
+            app_label,
+            RemoveEmbeddedField(
+                model_name=model_name,
+                name=field_name,
+            ),
+        )
+
+    def generate_altered_embedded_fields(self):
+        """
+        Make AlterEmbeddedField operations when an embedded column path
+        changes.
+        """
+        common = set(self.old_embedded_field_keys) & set(self.new_embedded_field_keys)
+        for app_label, model_name, field_name in sorted(common):
+            old_path = self.old_embedded_field_keys[app_label, model_name, field_name]
+            new_path = self.new_embedded_field_keys[app_label, model_name, field_name]
+            if old_path != new_path:
+                self._generate_altered_embedded_field(app_label, model_name, field_name)
+
+    def _generate_altered_embedded_field(self, app_label, model_name, field_name):
+        field = self.get_field(self.to_state.models[app_label, model_name], field_name)
+        # Navigate the path to locate the leaf embedded model for the ALTER
+        # dependency.
+        *parents, leaf_field_name = field_name.split(".")
+        current_app_label = app_label
+        current_model_name = model_name
+        for part in parents:
+            parent_field = self.to_state.models[current_app_label, current_model_name].get_field(
+                part
+            )
+            if hasattr(parent_field, "embedded_model"):
+                label_parts = parent_field.embedded_model.split(".")
+                if len(label_parts) == 2:
+                    current_app_label, current_model_name = label_parts
+                else:
+                    current_model_name = label_parts[0]
+        self.add_operation(
+            app_label,
+            AlterEmbeddedField(
+                model_name=model_name,
+                name=field_name,
+                field=field,
+            ),
+            dependencies=[
+                OperationDependency(
+                    current_app_label,
+                    current_model_name,
+                    leaf_field_name,
+                    OperationDependency.Type.ALTER,
+                )
+            ],
+        )
+
+    def get_field(self, model, field_name):
+        """
+        A version of ModelState.get_field() that can retrieve embedded model
+        fields.
+        """
+        path = []
+        base_model = model
+        *parents, leaf = field_name.split(".")
+        for i, name in enumerate(parents):
+            field = model.get_field(name)
+            path.append(getattr(field, "column", field.get_attname_column()[1]))
+            # For EmbeddedModelFields, advance to the embedded model and
+            # continue to loop, searching for the next field.
+            if hasattr(field, "embedded_model"):
+                model_lookup = tuple(field.embedded_model.split("."))
+                model = self.to_state.models[model_lookup]
+            # For PolymorphicEmbeddedModelFields, recurse into each embedded
+            # model until the field is found.
+            elif embedded_models := getattr(field, "embedded_models", None):
+                for submodel in embedded_models:
+                    with contextlib.suppress(FieldDoesNotExist):
+                        subfield = self.get_field(submodel, ".".join([*parents[i + 1 :], leaf]))
+                        path.extend(subfield.column.split("."))
+                        return FieldColumn(subfield.field, ".".join(path))
+                raise FieldDoesNotExist(
+                    f"The models of field '{'.'.join(parents)}' have no field named '{leaf}'."
+                )
+            else:
+                raise FieldDoesNotExist(f"{base_model.__name__} has no field named '{field_name}'.")
+        # Add the final field.
+        return model.get_field(leaf)

--- a/django_mongodb_backend/db/migrations/operations.py
+++ b/django_mongodb_backend/db/migrations/operations.py
@@ -1,6 +1,7 @@
 from django.db.migrations.operations import AddField, AlterField, RemoveField, RenameField
 from django.db.models import NOT_PROVIDED
 
+from django_mongodb_backend.fields import EmbeddedModelArrayField
 from django_mongodb_backend.indexes import get_field
 
 
@@ -38,7 +39,8 @@ def _embedded_column_path(state, app_label, model_name, attr_path):
     """
     Resolve a dotted Python attribute path to a dotted db_column path using
     state.models directly, avoiding stale class references from the app
-    registry.
+    registry. For EmbeddedModelArrayField segments, inserts '$[]' to target
+    all array elements.
     """
     columns = []
     current_app_label = app_label
@@ -46,7 +48,12 @@ def _embedded_column_path(state, app_label, model_name, attr_path):
     for part in attr_path.split("."):
         model_state = state.models[current_app_label, current_model_name]
         field = model_state.fields[part]
-        columns.append(field.db_column or part)
+        col = field.db_column or part
+        if isinstance(field, EmbeddedModelArrayField):
+            columns.append(col)
+            columns.append("$[]")
+        else:
+            columns.append(col)
         if hasattr(field, "embedded_model"):
             emb = field.embedded_model
             if not isinstance(emb, str):
@@ -120,14 +127,15 @@ class RemoveEmbeddedField(RemoveField):
     def database_forwards(self, app_label, schema_editor, from_state, to_state):
         from_model = from_state.apps.get_model(app_label, self.model_name)
         if self.allow_migrate_model(schema_editor.connection.alias, from_model):
-            # TODO: Does "self.name" account for db_column?
-            schema_editor.remove_embedded_field(from_model, self.name)
+            col_path = _embedded_column_path(from_state, app_label, self.model_name, self.name)
+            schema_editor.remove_embedded_field(from_model, col_path)
 
     def database_backwards(self, app_label, schema_editor, from_state, to_state):
         model = to_state.apps.get_model(app_label, self.model_name)
         if self.allow_migrate_model(schema_editor.connection.alias, model):
+            col_path = _embedded_column_path(to_state, app_label, self.model_name, self.name)
             field = get_field(model, self.name).field
-            schema_editor.add_embedded_field(model, self.name, field)
+            schema_editor.add_embedded_field(model, col_path, field)
 
     def describe(self):
         return f"Remove embedded field {self.name} from {self.model_name}"

--- a/django_mongodb_backend/db/migrations/operations.py
+++ b/django_mongodb_backend/db/migrations/operations.py
@@ -1,0 +1,141 @@
+from django.db.migrations.operations import AddField, AlterField, RemoveField, RenameField
+from django.db.models import NOT_PROVIDED
+
+from django_mongodb_backend.indexes import get_field
+
+
+class AddEmbeddedField(AddField):
+    def database_forwards(self, app_label, schema_editor, from_state, to_state):
+        to_model = to_state.apps.get_model(app_label, self.model_name)
+        if self.allow_migrate_model(schema_editor.connection.alias, to_model):
+            schema_editor.add_embedded_field(to_model, self.name, self.field)
+
+    def database_backwards(self, app_label, schema_editor, from_state, to_state):
+        from_model = from_state.apps.get_model(app_label, self.model_name)
+        if self.allow_migrate_model(schema_editor.connection.alias, from_model):
+            # TODO: Does "self.name" account for db_column?
+            schema_editor.remove_embedded_field(from_model, self.name)
+
+    def describe(self):
+        return f"Add embedded field {self.name} to {self.model_name}"
+
+    def state_forwards(self, app_label, state):
+        # If preserve default is off, don't use the default for future state.
+        if not self.preserve_default:
+            field = self.field.clone()
+            field.default = NOT_PROVIDED
+        else:
+            field = self.field
+        model_key = (app_label, self.model_name_lower)
+        state.reload_model(*model_key)
+
+    def state_backwards(self, app_label, state):
+        model_key = (app_label, self.model_name_lower)
+        state.reload_model(*model_key)
+
+
+def _embedded_column_path(state, app_label, model_name, attr_path):
+    """
+    Resolve a dotted Python attribute path to a dotted db_column path using
+    state.models directly, avoiding stale class references from the app
+    registry.
+    """
+    columns = []
+    current_app_label = app_label
+    current_model_name = model_name.lower()
+    for part in attr_path.split("."):
+        model_state = state.models[current_app_label, current_model_name]
+        field = model_state.fields[part]
+        columns.append(field.db_column or part)
+        if hasattr(field, "embedded_model"):
+            emb = field.embedded_model
+            if not isinstance(emb, str):
+                current_app_label = emb._meta.app_label
+                current_model_name = emb.__name__.lower()
+            elif "." in emb:
+                current_app_label, emb = emb.rsplit(".", 1)
+                current_model_name = emb.lower()
+            else:
+                current_model_name = emb.lower()
+    return ".".join(columns)
+
+
+class AlterEmbeddedField(AlterField):
+    def database_forwards(self, app_label, schema_editor, from_state, to_state):
+        to_model = to_state.apps.get_model(app_label, self.model_name)
+        if self.allow_migrate_model(schema_editor.connection.alias, to_model):
+            schema_editor.alter_embedded_field(
+                to_model,
+                _embedded_column_path(from_state, app_label, self.model_name, self.name),
+                _embedded_column_path(to_state, app_label, self.model_name, self.name),
+            )
+
+    def database_backwards(self, app_label, schema_editor, from_state, to_state):
+        self.database_forwards(app_label, schema_editor, from_state, to_state)
+
+    def describe(self):
+        return f"Alter embedded field {self.name} on {self.model_name}"
+
+    def state_forwards(self, app_label, state):
+        model_key = (app_label, self.model_name_lower)
+        state.reload_model(*model_key)
+
+    def state_backwards(self, app_label, state):
+        model_key = (app_label, self.model_name_lower)
+        state.reload_model(*model_key)
+
+
+class RenameEmbeddedField(RenameField):
+    def database_forwards(self, app_label, schema_editor, from_state, to_state):
+        to_model = to_state.apps.get_model(app_label, self.model_name)
+        if self.allow_migrate_model(schema_editor.connection.alias, to_model):
+            schema_editor.alter_embedded_field(
+                to_model,
+                _embedded_column_path(from_state, app_label, self.model_name, self.old_name),
+                _embedded_column_path(to_state, app_label, self.model_name, self.new_name),
+            )
+
+    def database_backwards(self, app_label, schema_editor, from_state, to_state):
+        to_model = to_state.apps.get_model(app_label, self.model_name)
+        if self.allow_migrate_model(schema_editor.connection.alias, to_model):
+            schema_editor.alter_embedded_field(
+                to_model,
+                _embedded_column_path(from_state, app_label, self.model_name, self.new_name),
+                _embedded_column_path(to_state, app_label, self.model_name, self.old_name),
+            )
+
+    def describe(self):
+        return f"Rename embedded field {self.old_name} on {self.model_name} to {self.new_name}"
+
+    def state_forwards(self, app_label, state):
+        model_key = (app_label, self.model_name_lower)
+        state.reload_model(*model_key)
+
+    def state_backwards(self, app_label, state):
+        model_key = (app_label, self.model_name_lower)
+        state.reload_model(*model_key)
+
+
+class RemoveEmbeddedField(RemoveField):
+    def database_forwards(self, app_label, schema_editor, from_state, to_state):
+        from_model = from_state.apps.get_model(app_label, self.model_name)
+        if self.allow_migrate_model(schema_editor.connection.alias, from_model):
+            # TODO: Does "self.name" account for db_column?
+            schema_editor.remove_embedded_field(from_model, self.name)
+
+    def database_backwards(self, app_label, schema_editor, from_state, to_state):
+        model = to_state.apps.get_model(app_label, self.model_name)
+        if self.allow_migrate_model(schema_editor.connection.alias, model):
+            field = get_field(model, self.name).field
+            schema_editor.add_embedded_field(model, self.name, field)
+
+    def describe(self):
+        return f"Remove embedded field {self.name} from {self.model_name}"
+
+    def state_forwards(self, app_label, state):
+        model_key = (app_label, self.model_name_lower)
+        state.reload_model(*model_key)
+
+    def state_backwards(self, app_label, state):
+        model_key = (app_label, self.model_name_lower)
+        state.reload_model(*model_key)

--- a/django_mongodb_backend/schema.py
+++ b/django_mongodb_backend/schema.py
@@ -537,16 +537,82 @@ class BaseSchemaEditor(BaseDatabaseSchemaEditor):
 
     # Embedded field operations
     def add_embedded_field(self, model, name, field):
-        # Set default value on existing documents.
-        self.get_collection(model._meta.db_table).update_many(
-            {}, [{"$set": {name: self.effective_default(field)}}]
-        )
+        default = self.effective_default(field)
+        if "$[]" in name:
+            # Aggregation pipeline $set doesn't support $[] positional
+            # operator.
+            self.get_collection(model._meta.db_table).update_many({}, {"$set": {name: default}})
+        else:
+            self.get_collection(model._meta.db_table).update_many({}, [{"$set": {name: default}}])
 
     def alter_embedded_field(self, model, old_name, new_name):
         if old_name != new_name:
-            self.get_collection(model._meta.db_table).update_many(
-                {}, {"$rename": {old_name: new_name}}
-            )
+            if "$[]" in old_name:
+                # $rename doesn't support the $[] positional operator.
+                self.get_collection(model._meta.db_table).update_many(
+                    {}, [self._build_array_rename_stage(old_name, new_name)]
+                )
+            else:
+                self.get_collection(model._meta.db_table).update_many(
+                    {}, {"$rename": {old_name: new_name}}
+                )
+
+    @staticmethod
+    def _build_array_rename_stage(old_name, new_name):
+        """
+        Build an aggregation pipeline $set stage that renames a field inside
+        array elements, handling arbitrary nesting after the $[] marker.
+        """
+        arr_prefix, old_inner = old_name.split(".$[].", 1)
+        new_inner = new_name.split(".$[].", 1)[1]
+        old_parts = old_inner.split(".")
+        old_leaf = old_parts[-1]
+        new_leaf = new_inner.split(".")[-1]
+        parent_parts = old_parts[:-1]
+
+        item_var = "item"
+        if parent_parts:
+            parent_path = ".".join(parent_parts)
+            inner_expr = {
+                "$unsetField": {
+                    "field": old_leaf,
+                    "input": {
+                        "$mergeObjects": [
+                            f"$${item_var}.{parent_path}",
+                            {new_leaf: f"$${item_var}.{old_inner}"},
+                        ]
+                    },
+                }
+            }
+            # Wrap outward from the parent leaf up to $$item.
+            for i in range(len(parent_parts) - 1, -1, -1):
+                ancestor_parts = parent_parts[:i]
+                ancestor_ref = (
+                    f"$${item_var}.{'.'.join(ancestor_parts)}"
+                    if ancestor_parts
+                    else f"$${item_var}"
+                )
+                inner_expr = {"$mergeObjects": [ancestor_ref, {parent_parts[i]: inner_expr}]}
+        else:
+            inner_expr = {
+                "$unsetField": {
+                    "field": old_leaf,
+                    "input": {
+                        "$mergeObjects": [f"$${item_var}", {new_leaf: f"$${item_var}.{old_inner}"}]
+                    },
+                }
+            }
+        return {
+            "$set": {
+                arr_prefix: {
+                    "$map": {
+                        "input": f"${arr_prefix}",
+                        "as": item_var,
+                        "in": inner_expr,
+                    }
+                }
+            }
+        }
 
     def remove_embedded_field(self, model, name):
         # Remove field from existing documents.

--- a/django_mongodb_backend/schema.py
+++ b/django_mongodb_backend/schema.py
@@ -535,6 +535,23 @@ class BaseSchemaEditor(BaseDatabaseSchemaEditor):
                 field_list.append(field_dict)
         return {"fields": field_list}
 
+    # Embedded field operations
+    def add_embedded_field(self, model, name, field):
+        # Set default value on existing documents.
+        self.get_collection(model._meta.db_table).update_many(
+            {}, [{"$set": {name: self.effective_default(field)}}]
+        )
+
+    def alter_embedded_field(self, model, old_name, new_name):
+        if old_name != new_name:
+            self.get_collection(model._meta.db_table).update_many(
+                {}, {"$rename": {old_name: new_name}}
+            )
+
+    def remove_embedded_field(self, model, name):
+        # Remove field from existing documents.
+        self.get_collection(model._meta.db_table).update_many({}, {"$unset": {name: ""}})
+
 
 # GISSchemaEditor extends some SchemaEditor methods.
 class DatabaseSchemaEditor(GISSchemaEditor, BaseSchemaEditor):

--- a/docs/ref/models/fields.rst
+++ b/docs/ref/models/fields.rst
@@ -313,15 +313,14 @@ These indexes use 0-based indexing.
     See :ref:`the embedded model topic guide <embedded-model-field-example>`
     for more details and examples.
 
-.. admonition:: Migrations support is limited
+.. admonition:: Migrations support
 
-    :djadmin:`makemigrations` does not yet detect changes to embedded models.
+    .. versionadded: 6.0.4
 
-    After you create a model with an ``EmbeddedModelField`` or add an
-    ``EmbeddedModelField`` to an existing model, no further updates to the
-    embedded model will be made. Using the models above as an example, if you
-    created these models and then add or remove a field from ``Address``,
-    existing documents won't be updated.
+    Django MongoDB Backend's custom :djadmin:`makemigrations` command detects
+    changes to embedded models referenced by ``EmbeddedModelField``. You must
+    have ``django_mongodb_backend`` in your :setting:`INSTALLED_APPS` setting
+    when running :djadmin:`makemigrations`.
 
 ``EmbeddedModelArrayField``
 ---------------------------
@@ -348,8 +347,12 @@ These indexes use 0-based indexing.
 
 .. admonition:: Migrations support is limited
 
-    As described above for :class:`EmbeddedModelField`,
-    :djadmin:`makemigrations` does not yet detect changes to embedded models.
+    :djadmin:`makemigrations` does not yet detect changes to embedded models
+    of ``EmbeddedModelArrayField``.
+
+    After you create a model with an ``EmbeddedModelFieldArray`` or add an
+    ``EmbeddedModelFieldArray`` to an existing model, no further schema updates
+    to the embedded model will be made.
 
 ``ObjectIdAutoField``
 ---------------------

--- a/docs/releases/6.0.x.rst
+++ b/docs/releases/6.0.x.rst
@@ -47,6 +47,11 @@ New features
   :class:`~django_mongodb_backend.indexes.VectorSearchIndex`, which allows
   specifying ``"hnsw"`` (server default) or ``"flat"`` for each vector field.
 
+- Added schema change support for ``EmbeddedModelField``. Fields in embedded
+  models referenced by ``EmbeddedModelField``\s will now be added, altered,
+  and removed. You must have ``django_mongodb_backend`` in your
+  :setting:`INSTALLED_APPS` setting when running :djadmin:`makemigrations`.
+
 Bug fixes
 ---------
 

--- a/tests/migrations_/autodetector/test_embedded_model_array_field.py
+++ b/tests/migrations_/autodetector/test_embedded_model_array_field.py
@@ -17,11 +17,7 @@ class EmbeddedModelArrayFieldAutodetectorTests(BaseAutodetectorTests):
     """Test the autodetector with EmbeddedModelArrayField."""
 
     def test_add_embedded_field(self):
-        """
-        Detection of new embedded fields (Author.age). No AddEmbeddedField is
-        generated since EmbeddedModelArrayField isn't supported by the
-        embedded-path autodetector logic.
-        """
+        """Detection of new embedded fields (Author.age)."""
         changes = self.get_changes(
             [
                 ModelState(
@@ -66,12 +62,16 @@ class EmbeddedModelArrayFieldAutodetectorTests(BaseAutodetectorTests):
             ],
         )
         self.assertNumberMigrations(changes, "testapp", 1)
-        self.assertOperationTypes(changes, "testapp", 0, ["AddField"])
+        self.assertOperationTypes(changes, "testapp", 0, ["AddField", "AddEmbeddedField"])
         self.assertOperationAttributes(changes, "testapp", 0, 0, model_name="author", name="age")
+        self.assertOperationAttributes(
+            changes, "testapp", 0, 1, model_name="book", name="author.$[].age"
+        )
 
     def test_add_embedded_field_db_column(self):
         """
-        No AddEmbeddedField is generated even when subfields use db_column.
+        AddEmbeddedField's name uses each field's db_column in embedded
+        paths.
         """
         changes = self.get_changes(
             [
@@ -117,8 +117,11 @@ class EmbeddedModelArrayFieldAutodetectorTests(BaseAutodetectorTests):
             ],
         )
         self.assertNumberMigrations(changes, "testapp", 1)
-        self.assertOperationTypes(changes, "testapp", 0, ["AddField"])
+        self.assertOperationTypes(changes, "testapp", 0, ["AddField", "AddEmbeddedField"])
         self.assertOperationAttributes(changes, "testapp", 0, 0, model_name="author", name="age")
+        self.assertOperationAttributes(
+            changes, "testapp", 0, 1, model_name="book", name="author.$[].the_age"
+        )
 
     @mock.patch(
         "django.db.migrations.questioner.MigrationQuestioner.ask_not_null_addition",
@@ -171,7 +174,9 @@ class EmbeddedModelArrayFieldAutodetectorTests(BaseAutodetectorTests):
             ],
         )
         self.assertNumberMigrations(changes, "testapp", 1)
-        self.assertOperationTypes(changes, "testapp", 0, ["AddField"] * 3)
+        self.assertOperationTypes(
+            changes, "testapp", 0, ["AddField"] * 3 + ["AddEmbeddedField"] * 3
+        )
         self.assertOperationAttributes(changes, "testapp", 0, 0, name="date", preserve_default=True)
         self.assertOperationFieldAttributes(changes, "testapp", 0, 0, auto_now=True)
         self.assertOperationFieldAttributes(changes, "testapp", 0, 1, auto_now=True)
@@ -230,7 +235,9 @@ class EmbeddedModelArrayFieldAutodetectorTests(BaseAutodetectorTests):
             ],
         )
         self.assertNumberMigrations(changes, "testapp", 1)
-        self.assertOperationTypes(changes, "testapp", 0, ["AddField"] * 3)
+        self.assertOperationTypes(
+            changes, "testapp", 0, ["AddField"] * 3 + ["AddEmbeddedField"] * 3
+        )
         self.assertOperationAttributes(
             changes, "testapp", 0, 0, name="date", preserve_default=False
         )
@@ -240,9 +247,21 @@ class EmbeddedModelArrayFieldAutodetectorTests(BaseAutodetectorTests):
         self.assertOperationAttributes(
             changes, "testapp", 0, 2, name="time", preserve_default=False
         )
+        self.assertOperationAttributes(
+            changes, "testapp", 0, 3, name="author.$[].date", preserve_default=False
+        )
+        self.assertOperationAttributes(
+            changes, "testapp", 0, 4, name="author.$[].datetime", preserve_default=False
+        )
+        self.assertOperationAttributes(
+            changes, "testapp", 0, 5, name="author.$[].time", preserve_default=False
+        )
         self.assertOperationFieldAttributes(changes, "testapp", 0, 0, auto_now_add=True)
         self.assertOperationFieldAttributes(changes, "testapp", 0, 1, auto_now_add=True)
         self.assertOperationFieldAttributes(changes, "testapp", 0, 2, auto_now_add=True)
+        self.assertOperationFieldAttributes(changes, "testapp", 0, 3, auto_now_add=True)
+        self.assertOperationFieldAttributes(changes, "testapp", 0, 4, auto_now_add=True)
+        self.assertOperationFieldAttributes(changes, "testapp", 0, 5, auto_now_add=True)
 
     @mock.patch("django.db.migrations.questioner.MigrationQuestioner.ask_auto_now_add_addition")
     def test_add_date_fields_with_auto_now_add_asking_for_default(self, mocked_ask_method):
@@ -292,7 +311,9 @@ class EmbeddedModelArrayFieldAutodetectorTests(BaseAutodetectorTests):
             ],
         )
         self.assertNumberMigrations(changes, "testapp", 1)
-        self.assertOperationTypes(changes, "testapp", 0, ["AddField"] * 3)
+        self.assertOperationTypes(
+            changes, "testapp", 0, ["AddField"] * 3 + ["AddEmbeddedField"] * 3
+        )
         self.assertOperationAttributes(
             changes, "testapp", 0, 0, name="date", preserve_default=False
         )
@@ -310,7 +331,6 @@ class EmbeddedModelArrayFieldAutodetectorTests(BaseAutodetectorTests):
     def test_add_nested_embedded_field(self):
         """
         Detection of new nested embedded fields (Book.author[*].bio.title).
-        No AddEmbeddedField is generated for the array field container.
         """
         changes = self.get_changes(
             [
@@ -374,8 +394,11 @@ class EmbeddedModelArrayFieldAutodetectorTests(BaseAutodetectorTests):
             ],
         )
         self.assertNumberMigrations(changes, "testapp", 1)
-        self.assertOperationTypes(changes, "testapp", 0, ["AddField"])
+        self.assertOperationTypes(changes, "testapp", 0, ["AddField", "AddEmbeddedField"])
         self.assertOperationAttributes(changes, "testapp", 0, 0, model_name="bio", name="title")
+        self.assertOperationAttributes(
+            changes, "testapp", 0, 1, model_name="book", name="author.$[].bio.title"
+        )
 
     def test_add_embedded_model_field(self):
         """Detection of new EmbeddedModelArrayField (Book.author)."""
@@ -426,8 +449,7 @@ class EmbeddedModelArrayFieldAutodetectorTests(BaseAutodetectorTests):
 
     def test_add_nested_embedded_model_field(self):
         """
-        Adding a nested EmbeddedModelField inside an embedded-array Author
-        generates only AddField for the Author-level field.
+        Adding a nested EmbeddedModelField inside an embedded-array Author.
         """
         changes = self.get_changes(
             [
@@ -491,14 +513,14 @@ class EmbeddedModelArrayFieldAutodetectorTests(BaseAutodetectorTests):
             ],
         )
         self.assertNumberMigrations(changes, "testapp", 1)
-        self.assertOperationTypes(changes, "testapp", 0, ["AddField"])
+        self.assertOperationTypes(changes, "testapp", 0, ["AddField", "AddEmbeddedField"])
         self.assertOperationAttributes(changes, "testapp", 0, 0, model_name="author", name="bio")
+        self.assertOperationAttributes(
+            changes, "testapp", 0, 1, model_name="book", name="author.$[].bio"
+        )
 
     def test_remove_embedded_field(self):
-        """
-        Tests autodetection of removed fields. No RemoveEmbeddedField is
-        generated.
-        """
+        """Detection of removed embedded fields."""
         changes = self.get_changes(
             [
                 ModelState(
@@ -542,14 +564,14 @@ class EmbeddedModelArrayFieldAutodetectorTests(BaseAutodetectorTests):
             ],
         )
         self.assertNumberMigrations(changes, "testapp", 1)
-        self.assertOperationTypes(changes, "testapp", 0, ["RemoveField"])
+        self.assertOperationTypes(changes, "testapp", 0, ["RemoveField", "RemoveEmbeddedField"])
         self.assertOperationAttributes(changes, "testapp", 0, 0, name="name")
+        self.assertOperationAttributes(
+            changes, "testapp", 0, 1, model_name="book", name="author.name"
+        )
 
     def test_remove_nested_embedded_field(self):
-        """
-        Detection of removed nested embedded fields. No RemoveEmbeddedField is
-        generated for the array field container.
-        """
+        """Detection of removed nested embedded fields."""
         changes = self.get_changes(
             [
                 ModelState(
@@ -613,13 +635,14 @@ class EmbeddedModelArrayFieldAutodetectorTests(BaseAutodetectorTests):
             ],
         )
         self.assertNumberMigrations(changes, "testapp", 1)
-        self.assertOperationTypes(changes, "testapp", 0, ["RemoveField"])
+        self.assertOperationTypes(changes, "testapp", 0, ["RemoveField", "RemoveEmbeddedField"])
         self.assertOperationAttributes(changes, "testapp", 0, 0, model_name="bio", name="title")
+        self.assertOperationAttributes(
+            changes, "testapp", 0, 1, model_name="book", name="author.bio.title"
+        )
 
     def test_alter_embedded_field(self):
-        """
-        Detection of db_column change. No AlterEmbeddedField is generated.
-        """
+        """Detection of db_column change generates AlterEmbeddedField."""
         changes = self.get_changes(
             [
                 ModelState(
@@ -663,13 +686,15 @@ class EmbeddedModelArrayFieldAutodetectorTests(BaseAutodetectorTests):
             ],
         )
         self.assertNumberMigrations(changes, "testapp", 1)
-        self.assertOperationTypes(changes, "testapp", 0, ["AlterField"])
+        self.assertOperationTypes(changes, "testapp", 0, ["AlterField", "AlterEmbeddedField"])
         self.assertOperationAttributes(changes, "testapp", 0, 0, model_name="author", name="name")
+        self.assertOperationAttributes(
+            changes, "testapp", 0, 1, model_name="book", name="author.name"
+        )
 
     def test_rename_embedded_field(self):
         """
-        Detection of renamed embedded fields. No RenameEmbeddedField is
-        generated for the array field container.
+        Detection of renamed embedded fields generates RenameEmbeddedField.
         """
         changes = self.get_changes(
             [
@@ -715,9 +740,18 @@ class EmbeddedModelArrayFieldAutodetectorTests(BaseAutodetectorTests):
             MigrationQuestioner({"ask_rename": True}),
         )
         self.assertNumberMigrations(changes, "testapp", 1)
-        self.assertOperationTypes(changes, "testapp", 0, ["RenameField"])
+        self.assertOperationTypes(changes, "testapp", 0, ["RenameField", "RenameEmbeddedField"])
         self.assertOperationAttributes(
             changes, "testapp", 0, 0, model_name="author", old_name="name", new_name="full_name"
+        )
+        self.assertOperationAttributes(
+            changes,
+            "testapp",
+            0,
+            1,
+            model_name="book",
+            old_name="author.name",
+            new_name="author.full_name",
         )
 
     def test_alter_embbedded_field_max_length(self):
@@ -927,9 +961,7 @@ class EmbeddedModelArrayFieldAutodetectorTests(BaseAutodetectorTests):
         self.assertOperationFieldAttributes(changes, "testapp", 0, 0, default="Some Name")
 
     def test_rename_field(self):
-        """
-        Renaming a field generates only RenameField, not RenameEmbeddedField.
-        """
+        """Renaming a field generates RenameField and RenameEmbeddedField."""
         changes = self.get_changes(
             [
                 ModelState(
@@ -972,15 +1004,24 @@ class EmbeddedModelArrayFieldAutodetectorTests(BaseAutodetectorTests):
             MigrationQuestioner({"ask_rename": True}),
         )
         self.assertNumberMigrations(changes, "testapp", 1)
-        self.assertOperationTypes(changes, "testapp", 0, ["RenameField"])
+        self.assertOperationTypes(changes, "testapp", 0, ["RenameField", "RenameEmbeddedField"])
         self.assertOperationAttributes(
             changes, "testapp", 0, 0, model_name="author", old_name="name", new_name="names"
+        )
+        self.assertOperationAttributes(
+            changes,
+            "testapp",
+            0,
+            1,
+            model_name="book",
+            old_name="author.name",
+            new_name="author.names",
         )
 
     def test_rename_field_preserved_db_column(self):
         """
-        RenameField is used if a field is renamed and db_column equal to the
-        old field's column is added. No RenameEmbeddedField is generated.
+        RenameField and RenameEmbeddedField are used if a field is renamed and
+        db_column equal to the old field's column is added.
         """
         before = [
             ModelState(
@@ -1022,7 +1063,9 @@ class EmbeddedModelArrayFieldAutodetectorTests(BaseAutodetectorTests):
         ]
         changes = self.get_changes(before, after, MigrationQuestioner({"ask_rename": True}))
         self.assertNumberMigrations(changes, "testapp", 1)
-        self.assertOperationTypes(changes, "testapp", 0, ["AlterField", "RenameField"])
+        self.assertOperationTypes(
+            changes, "testapp", 0, ["AlterField", "RenameField", "RenameEmbeddedField"]
+        )
         self.assertOperationAttributes(
             changes,
             "testapp",
@@ -1049,9 +1092,20 @@ class EmbeddedModelArrayFieldAutodetectorTests(BaseAutodetectorTests):
             old_name="field",
             new_name="renamed_field",
         )
+        self.assertOperationAttributes(
+            changes,
+            "testapp",
+            0,
+            2,
+            model_name="book",
+            old_name="author.field",
+            new_name="author.renamed_field",
+        )
 
     def test_add_field_with_default(self):
-        """Adding a field with a default generates only AddField."""
+        """
+        Adding a field with a default generates AddField and AddEmbeddedField.
+        """
         before = [
             ModelState(
                 "testapp",
@@ -1091,8 +1145,11 @@ class EmbeddedModelArrayFieldAutodetectorTests(BaseAutodetectorTests):
         ]
         changes = self.get_changes(before, after)
         self.assertNumberMigrations(changes, "testapp", 1)
-        self.assertOperationTypes(changes, "testapp", 0, ["AddField"])
+        self.assertOperationTypes(changes, "testapp", 0, ["AddField", "AddEmbeddedField"])
         self.assertOperationAttributes(changes, "testapp", 0, 0, name="name")
+        self.assertOperationAttributes(
+            changes, "testapp", 0, 1, model_name="book", name="author.$[].name"
+        )
 
     @mock.patch(
         "django.db.migrations.questioner.MigrationQuestioner.ask_not_null_addition",
@@ -1143,13 +1200,15 @@ class EmbeddedModelArrayFieldAutodetectorTests(BaseAutodetectorTests):
         ]
         changes = self.get_changes(before, after)
         self.assertNumberMigrations(changes, "testapp", 1)
-        self.assertOperationTypes(changes, "testapp", 0, ["AddField", "AddField"])
+        self.assertOperationTypes(
+            changes, "testapp", 0, ["AddField", "AddField", "AddEmbeddedField", "AddEmbeddedField"]
+        )
 
     @mock.patch("django.db.migrations.questioner.MigrationQuestioner.ask_not_null_addition")
     def test_add_non_blank_textfield_and_charfield(self, mocked_ask_method):
         """
         Adding a NOT NULL and non-blank CharField or TextField without default
-        should prompt for a default once per field (no AddEmbeddedField calls).
+        prompts once per field; AddEmbeddedField reuses the same default.
         """
         before = [
             ModelState(
@@ -1192,4 +1251,6 @@ class EmbeddedModelArrayFieldAutodetectorTests(BaseAutodetectorTests):
         changes = self.get_changes(before, after)
         self.assertEqual(mocked_ask_method.call_count, 2)
         self.assertNumberMigrations(changes, "testapp", 1)
-        self.assertOperationTypes(changes, "testapp", 0, ["AddField", "AddField"])
+        self.assertOperationTypes(
+            changes, "testapp", 0, ["AddField", "AddField", "AddEmbeddedField", "AddEmbeddedField"]
+        )

--- a/tests/migrations_/autodetector/test_embedded_model_array_field.py
+++ b/tests/migrations_/autodetector/test_embedded_model_array_field.py
@@ -1,0 +1,1195 @@
+from unittest import mock
+
+from django.db import models
+from django.db.migrations.questioner import MigrationQuestioner
+from django.db.migrations.state import ModelState
+
+from django_mongodb_backend.fields import (
+    EmbeddedModelArrayField,
+    EmbeddedModelField,
+    ObjectIdAutoField,
+)
+
+from .base import BaseAutodetectorTests
+
+
+class EmbeddedModelArrayFieldAutodetectorTests(BaseAutodetectorTests):
+    """Test the autodetector with EmbeddedModelArrayField."""
+
+    def test_add_embedded_field(self):
+        """
+        Detection of new embedded fields (Author.age). No AddEmbeddedField is
+        generated since EmbeddedModelArrayField isn't supported by the
+        embedded-path autodetector logic.
+        """
+        changes = self.get_changes(
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=200)),
+                        ("author", EmbeddedModelArrayField("testapp.author")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=10)),
+                    ],
+                    {"managed": False},
+                ),
+            ],
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=200)),
+                        ("author", EmbeddedModelArrayField("testapp.author")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=10)),
+                        ("age", models.IntegerField()),
+                    ],
+                    {"managed": False},
+                ),
+            ],
+        )
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(changes, "testapp", 0, ["AddField"])
+        self.assertOperationAttributes(changes, "testapp", 0, 0, model_name="author", name="age")
+
+    def test_add_embedded_field_db_column(self):
+        """
+        No AddEmbeddedField is generated even when subfields use db_column.
+        """
+        changes = self.get_changes(
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=200)),
+                        ("author", EmbeddedModelArrayField("testapp.author")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=10)),
+                    ],
+                    {"managed": False},
+                ),
+            ],
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=200)),
+                        ("author", EmbeddedModelArrayField("testapp.author")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=10)),
+                        ("age", models.IntegerField(db_column="the_age")),
+                    ],
+                    {"managed": False},
+                ),
+            ],
+        )
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(changes, "testapp", 0, ["AddField"])
+        self.assertOperationAttributes(changes, "testapp", 0, 0, model_name="author", name="age")
+
+    @mock.patch(
+        "django.db.migrations.questioner.MigrationQuestioner.ask_not_null_addition",
+        side_effect=AssertionError("Should not have prompted for not null addition"),
+    )
+    def test_add_date_fields_with_auto_now_not_asking_for_default(self, mocked_ask_method):
+        changes = self.get_changes(
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=200)),
+                        ("author", EmbeddedModelArrayField("testapp.author")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=10)),
+                    ],
+                    {"managed": False},
+                ),
+            ],
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=200)),
+                        ("author", EmbeddedModelArrayField("testapp.author")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=10)),
+                        ("date", models.DateField(auto_now=True)),
+                        ("datetime", models.DateTimeField(auto_now=True)),
+                        ("time", models.TimeField(auto_now=True)),
+                    ],
+                    {"managed": False},
+                ),
+            ],
+        )
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(changes, "testapp", 0, ["AddField"] * 3)
+        self.assertOperationAttributes(changes, "testapp", 0, 0, name="date", preserve_default=True)
+        self.assertOperationFieldAttributes(changes, "testapp", 0, 0, auto_now=True)
+        self.assertOperationFieldAttributes(changes, "testapp", 0, 1, auto_now=True)
+        self.assertOperationFieldAttributes(changes, "testapp", 0, 2, auto_now=True)
+
+    @mock.patch(
+        "django.db.migrations.questioner.MigrationQuestioner.ask_not_null_addition",
+        side_effect=AssertionError("Should not have prompted for not null addition"),
+    )
+    def test_add_date_fields_with_auto_now_add_not_asking_for_null_addition(
+        self, mocked_ask_method
+    ):
+        changes = self.get_changes(
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=200)),
+                        ("author", EmbeddedModelArrayField("testapp.author")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=10)),
+                    ],
+                    {"managed": False},
+                ),
+            ],
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=200)),
+                        ("author", EmbeddedModelArrayField("testapp.author")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=10)),
+                        ("date", models.DateField(auto_now_add=True)),
+                        ("datetime", models.DateTimeField(auto_now_add=True)),
+                        ("time", models.TimeField(auto_now_add=True)),
+                    ],
+                    {"managed": False},
+                ),
+            ],
+        )
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(changes, "testapp", 0, ["AddField"] * 3)
+        self.assertOperationAttributes(
+            changes, "testapp", 0, 0, name="date", preserve_default=False
+        )
+        self.assertOperationAttributes(
+            changes, "testapp", 0, 1, name="datetime", preserve_default=False
+        )
+        self.assertOperationAttributes(
+            changes, "testapp", 0, 2, name="time", preserve_default=False
+        )
+        self.assertOperationFieldAttributes(changes, "testapp", 0, 0, auto_now_add=True)
+        self.assertOperationFieldAttributes(changes, "testapp", 0, 1, auto_now_add=True)
+        self.assertOperationFieldAttributes(changes, "testapp", 0, 2, auto_now_add=True)
+
+    @mock.patch("django.db.migrations.questioner.MigrationQuestioner.ask_auto_now_add_addition")
+    def test_add_date_fields_with_auto_now_add_asking_for_default(self, mocked_ask_method):
+        changes = self.get_changes(
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=200)),
+                        ("author", EmbeddedModelArrayField("testapp.author")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=10)),
+                    ],
+                    {"managed": False},
+                ),
+            ],
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=200)),
+                        ("author", EmbeddedModelArrayField("testapp.author")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=10)),
+                        ("date", models.DateField(auto_now_add=True)),
+                        ("datetime", models.DateTimeField(auto_now_add=True)),
+                        ("time", models.TimeField(auto_now_add=True)),
+                    ],
+                    {"managed": False},
+                ),
+            ],
+        )
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(changes, "testapp", 0, ["AddField"] * 3)
+        self.assertOperationAttributes(
+            changes, "testapp", 0, 0, name="date", preserve_default=False
+        )
+        self.assertOperationAttributes(
+            changes, "testapp", 0, 1, name="datetime", preserve_default=False
+        )
+        self.assertOperationAttributes(
+            changes, "testapp", 0, 2, name="time", preserve_default=False
+        )
+        self.assertOperationFieldAttributes(changes, "testapp", 0, 0, auto_now_add=True)
+        self.assertOperationFieldAttributes(changes, "testapp", 0, 1, auto_now_add=True)
+        self.assertOperationFieldAttributes(changes, "testapp", 0, 2, auto_now_add=True)
+        self.assertEqual(mocked_ask_method.call_count, 3)
+
+    def test_add_nested_embedded_field(self):
+        """
+        Detection of new nested embedded fields (Book.author[*].bio.title).
+        No AddEmbeddedField is generated for the array field container.
+        """
+        changes = self.get_changes(
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=200)),
+                        ("author", EmbeddedModelArrayField("testapp.author")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=10)),
+                        ("bio", EmbeddedModelField("testapp.bio")),
+                    ],
+                    {"managed": False},
+                ),
+                ModelState(
+                    "testapp",
+                    "Bio",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                    ],
+                    {"managed": False},
+                ),
+            ],
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=200)),
+                        ("author", EmbeddedModelArrayField("testapp.author")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=10)),
+                        ("bio", EmbeddedModelField("testapp.bio")),
+                    ],
+                    {"managed": False},
+                ),
+                ModelState(
+                    "testapp",
+                    "Bio",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("title", models.CharField(max_length=10)),  # Added
+                    ],
+                    {"managed": False},
+                ),
+            ],
+        )
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(changes, "testapp", 0, ["AddField"])
+        self.assertOperationAttributes(changes, "testapp", 0, 0, model_name="bio", name="title")
+
+    def test_add_embedded_model_field(self):
+        """Detection of new EmbeddedModelArrayField (Book.author)."""
+        changes = self.get_changes(
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=200)),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=10)),
+                    ],
+                    {"managed": False},
+                ),
+            ],
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=200)),
+                        ("author", EmbeddedModelArrayField("testapp.author")),  # Added
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=10)),
+                    ],
+                    {"managed": False},
+                ),
+            ],
+        )
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(changes, "testapp", 0, ["AddField"])
+        self.assertOperationAttributes(changes, "testapp", 0, 0, model_name="book", name="author")
+
+    def test_add_nested_embedded_model_field(self):
+        """
+        Adding a nested EmbeddedModelField inside an embedded-array Author
+        generates only AddField for the Author-level field.
+        """
+        changes = self.get_changes(
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=200)),
+                        ("author", EmbeddedModelArrayField("testapp.author")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=10)),
+                    ],
+                    {"managed": False},
+                ),
+                ModelState(
+                    "testapp",
+                    "Bio",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("title", models.CharField(max_length=10)),
+                    ],
+                    {"managed": False},
+                ),
+            ],
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=200)),
+                        ("author", EmbeddedModelArrayField("testapp.author")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=10)),
+                        ("bio", EmbeddedModelField("testapp.bio")),  # Added
+                    ],
+                    {"managed": False},
+                ),
+                ModelState(
+                    "testapp",
+                    "Bio",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("title", models.CharField(max_length=10)),
+                    ],
+                    {"managed": False},
+                ),
+            ],
+        )
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(changes, "testapp", 0, ["AddField"])
+        self.assertOperationAttributes(changes, "testapp", 0, 0, model_name="author", name="bio")
+
+    def test_remove_embedded_field(self):
+        """
+        Tests autodetection of removed fields. No RemoveEmbeddedField is
+        generated.
+        """
+        changes = self.get_changes(
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=200)),
+                        ("author", EmbeddedModelArrayField("testapp.author")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=10)),
+                    ],
+                    {"managed": False},
+                ),
+            ],
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=200)),
+                        ("author", EmbeddedModelArrayField("testapp.author")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        # Removed name
+                    ],
+                    {"managed": False},
+                ),
+            ],
+        )
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(changes, "testapp", 0, ["RemoveField"])
+        self.assertOperationAttributes(changes, "testapp", 0, 0, name="name")
+
+    def test_remove_nested_embedded_field(self):
+        """
+        Detection of removed nested embedded fields. No RemoveEmbeddedField is
+        generated for the array field container.
+        """
+        changes = self.get_changes(
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=200)),
+                        ("author", EmbeddedModelArrayField("testapp.author")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=10)),
+                        ("bio", EmbeddedModelField("testapp.bio")),
+                    ],
+                    {"managed": False},
+                ),
+                ModelState(
+                    "testapp",
+                    "Bio",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("title", models.CharField(max_length=10)),
+                    ],
+                    {"managed": False},
+                ),
+            ],
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=200)),
+                        ("author", EmbeddedModelArrayField("testapp.author")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=10)),
+                        ("bio", EmbeddedModelField("testapp.bio")),
+                    ],
+                    {"managed": False},
+                ),
+                ModelState(
+                    "testapp",
+                    "Bio",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        # Removed title
+                    ],
+                    {"managed": False},
+                ),
+            ],
+        )
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(changes, "testapp", 0, ["RemoveField"])
+        self.assertOperationAttributes(changes, "testapp", 0, 0, model_name="bio", name="title")
+
+    def test_alter_embedded_field(self):
+        """
+        Detection of db_column change. No AlterEmbeddedField is generated.
+        """
+        changes = self.get_changes(
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=200)),
+                        ("author", EmbeddedModelArrayField("testapp.author")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=10)),
+                    ],
+                    {"managed": False},
+                ),
+            ],
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=200)),
+                        ("author", EmbeddedModelArrayField("testapp.author")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=10, db_column="the_name")),
+                    ],
+                    {"managed": False},
+                ),
+            ],
+        )
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(changes, "testapp", 0, ["AlterField"])
+        self.assertOperationAttributes(changes, "testapp", 0, 0, model_name="author", name="name")
+
+    def test_rename_embedded_field(self):
+        """
+        Detection of renamed embedded fields. No RenameEmbeddedField is
+        generated for the array field container.
+        """
+        changes = self.get_changes(
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=200)),
+                        ("author", EmbeddedModelArrayField("testapp.author")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=10)),
+                    ],
+                    {"managed": False},
+                ),
+            ],
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=200)),
+                        ("author", EmbeddedModelArrayField("testapp.author")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("full_name", models.CharField(max_length=10)),
+                    ],
+                    {"managed": False},
+                ),
+            ],
+            MigrationQuestioner({"ask_rename": True}),
+        )
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(changes, "testapp", 0, ["RenameField"])
+        self.assertOperationAttributes(
+            changes, "testapp", 0, 0, model_name="author", old_name="name", new_name="full_name"
+        )
+
+    def test_alter_embbedded_field_max_length(self):
+        """Only AlterField is generated for max_length changes."""
+        changes = self.get_changes(
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=200)),
+                        ("author", EmbeddedModelArrayField("testapp.author")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=10)),
+                    ],
+                    {"managed": False},
+                ),
+            ],
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=200)),
+                        ("author", EmbeddedModelArrayField("testapp.author")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=15)),  # max_length increased
+                    ],
+                    {"managed": False},
+                ),
+            ],
+        )
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(changes, "testapp", 0, ["AlterField"])
+        self.assertOperationAttributes(changes, "testapp", 0, 0, model_name="author", name="name")
+
+    @mock.patch(
+        "django.db.migrations.questioner.MigrationQuestioner.ask_not_null_alteration",
+        side_effect=AssertionError("Should not have prompted for not null alteration"),
+    )
+    def test_alter_field_to_not_null_with_default(self, mocked_ask_method):
+        """
+        Nullable to non-nullable alteration with a default doesn't prompt.
+        """
+        before = [
+            ModelState(
+                "testapp",
+                "Book",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("author", EmbeddedModelArrayField("testapp.author")),
+                ],
+            ),
+            ModelState(
+                "testapp",
+                "Author",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("name", models.CharField(max_length=10, null=True)),
+                ],
+                {"managed": False},
+            ),
+        ]
+        after = [
+            ModelState(
+                "testapp",
+                "Book",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("author", EmbeddedModelArrayField("testapp.author")),
+                ],
+            ),
+            ModelState(
+                "testapp",
+                "Author",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("name", models.CharField(max_length=10, default="Ada Lovelace")),
+                ],
+                {"managed": False},
+            ),
+        ]
+        changes = self.get_changes(before, after)
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(changes, "testapp", 0, ["AlterField"])
+        self.assertOperationAttributes(changes, "testapp", 0, 0, name="name", preserve_default=True)
+        self.assertOperationFieldAttributes(changes, "testapp", 0, 0, default="Ada Lovelace")
+
+    @mock.patch(
+        "django.db.migrations.questioner.MigrationQuestioner.ask_not_null_alteration",
+        return_value=models.NOT_PROVIDED,
+    )
+    def test_alter_field_to_not_null_without_default(self, mocked_ask_method):
+        """
+        Nullable to non-nullable alteration without a default prompts once.
+        """
+        before = [
+            ModelState(
+                "testapp",
+                "Book",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("author", EmbeddedModelArrayField("testapp.author")),
+                ],
+            ),
+            ModelState(
+                "testapp",
+                "Author",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("name", models.CharField(max_length=10, null=True)),
+                ],
+                {"managed": False},
+            ),
+        ]
+        after = [
+            ModelState(
+                "testapp",
+                "Book",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("author", EmbeddedModelArrayField("testapp.author")),
+                ],
+            ),
+            ModelState(
+                "testapp",
+                "Author",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("name", models.CharField(max_length=10)),
+                ],
+                {"managed": False},
+            ),
+        ]
+        changes = self.get_changes(before, after)
+        self.assertEqual(mocked_ask_method.call_count, 1)
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(changes, "testapp", 0, ["AlterField"])
+        self.assertOperationAttributes(changes, "testapp", 0, 0, name="name", preserve_default=True)
+        self.assertOperationFieldAttributes(changes, "testapp", 0, 0, default=models.NOT_PROVIDED)
+
+    @mock.patch(
+        "django.db.migrations.questioner.MigrationQuestioner.ask_not_null_alteration",
+        return_value="Some Name",
+    )
+    def test_alter_field_to_not_null_oneoff_default(self, mocked_ask_method):
+        """Nullable to non-nullable alteration with a one-off default."""
+        before = [
+            ModelState(
+                "testapp",
+                "Book",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("author", EmbeddedModelArrayField("testapp.author")),
+                ],
+            ),
+            ModelState(
+                "testapp",
+                "Author",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("name", models.CharField(max_length=10, null=True)),
+                ],
+                {"managed": False},
+            ),
+        ]
+        after = [
+            ModelState(
+                "testapp",
+                "Book",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("author", EmbeddedModelArrayField("testapp.author")),
+                ],
+            ),
+            ModelState(
+                "testapp",
+                "Author",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("name", models.CharField(max_length=10)),
+                ],
+                {"managed": False},
+            ),
+        ]
+        changes = self.get_changes(before, after)
+        self.assertEqual(mocked_ask_method.call_count, 1)
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(changes, "testapp", 0, ["AlterField"])
+        self.assertOperationAttributes(
+            changes, "testapp", 0, 0, name="name", preserve_default=False
+        )
+        self.assertOperationFieldAttributes(changes, "testapp", 0, 0, default="Some Name")
+
+    def test_rename_field(self):
+        """
+        Renaming a field generates only RenameField, not RenameEmbeddedField.
+        """
+        changes = self.get_changes(
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("author", EmbeddedModelArrayField("testapp.author")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=10)),
+                    ],
+                    {"managed": False},
+                ),
+            ],
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("author", EmbeddedModelArrayField("testapp.author")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("names", models.CharField(max_length=10)),
+                    ],
+                    {"managed": False},
+                ),
+            ],
+            MigrationQuestioner({"ask_rename": True}),
+        )
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(changes, "testapp", 0, ["RenameField"])
+        self.assertOperationAttributes(
+            changes, "testapp", 0, 0, model_name="author", old_name="name", new_name="names"
+        )
+
+    def test_rename_field_preserved_db_column(self):
+        """
+        RenameField is used if a field is renamed and db_column equal to the
+        old field's column is added. No RenameEmbeddedField is generated.
+        """
+        before = [
+            ModelState(
+                "testapp",
+                "Book",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("author", EmbeddedModelArrayField("testapp.author")),
+                ],
+            ),
+            ModelState(
+                "testapp",
+                "Author",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("field", models.IntegerField()),
+                ],
+                {"managed": False},
+            ),
+        ]
+        after = [
+            ModelState(
+                "testapp",
+                "Book",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("author", EmbeddedModelArrayField("testapp.author")),
+                ],
+            ),
+            ModelState(
+                "testapp",
+                "Author",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("renamed_field", models.IntegerField(db_column="field")),
+                ],
+                {"managed": False},
+            ),
+        ]
+        changes = self.get_changes(before, after, MigrationQuestioner({"ask_rename": True}))
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(changes, "testapp", 0, ["AlterField", "RenameField"])
+        self.assertOperationAttributes(
+            changes,
+            "testapp",
+            0,
+            0,
+            model_name="author",
+            name="field",
+        )
+        self.assertEqual(
+            changes["testapp"][0].operations[0].field.deconstruct(),
+            (
+                "field",
+                "django.db.models.IntegerField",
+                [],
+                {"db_column": "field"},
+            ),
+        )
+        self.assertOperationAttributes(
+            changes,
+            "testapp",
+            0,
+            1,
+            model_name="author",
+            old_name="field",
+            new_name="renamed_field",
+        )
+
+    def test_add_field_with_default(self):
+        """Adding a field with a default generates only AddField."""
+        before = [
+            ModelState(
+                "testapp",
+                "Book",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("author", EmbeddedModelArrayField("testapp.author")),
+                ],
+            ),
+            ModelState(
+                "testapp",
+                "Author",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                ],
+                {"managed": False},
+            ),
+        ]
+        after = [
+            ModelState(
+                "testapp",
+                "Book",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("author", EmbeddedModelArrayField("testapp.author")),
+                ],
+            ),
+            ModelState(
+                "testapp",
+                "Author",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("name", models.CharField(max_length=10, default="Ada Lovelace")),
+                ],
+                {"managed": False},
+            ),
+        ]
+        changes = self.get_changes(before, after)
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(changes, "testapp", 0, ["AddField"])
+        self.assertOperationAttributes(changes, "testapp", 0, 0, name="name")
+
+    @mock.patch(
+        "django.db.migrations.questioner.MigrationQuestioner.ask_not_null_addition",
+        side_effect=AssertionError("Should not have prompted for not null addition"),
+    )
+    def test_add_blank_textfield_and_charfield(self, mocked_ask_method):
+        """
+        Adding a NOT NULL and blank CharField or TextField without default
+        should not prompt for a default.
+        """
+        before = [
+            ModelState(
+                "testapp",
+                "Book",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("author", EmbeddedModelArrayField("testapp.author")),
+                ],
+            ),
+            ModelState(
+                "testapp",
+                "Author",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                ],
+                {"managed": False},
+            ),
+        ]
+        after = [
+            ModelState(
+                "testapp",
+                "Book",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("author", EmbeddedModelArrayField("testapp.author")),
+                ],
+            ),
+            ModelState(
+                "testapp",
+                "Author",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("biography", models.TextField(blank=True)),
+                    ("name", models.CharField(max_length=10, blank=True)),
+                ],
+                {"managed": False},
+            ),
+        ]
+        changes = self.get_changes(before, after)
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(changes, "testapp", 0, ["AddField", "AddField"])
+
+    @mock.patch("django.db.migrations.questioner.MigrationQuestioner.ask_not_null_addition")
+    def test_add_non_blank_textfield_and_charfield(self, mocked_ask_method):
+        """
+        Adding a NOT NULL and non-blank CharField or TextField without default
+        should prompt for a default once per field (no AddEmbeddedField calls).
+        """
+        before = [
+            ModelState(
+                "testapp",
+                "Book",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("author", EmbeddedModelArrayField("testapp.author")),
+                ],
+            ),
+            ModelState(
+                "testapp",
+                "Author",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                ],
+                {"managed": False},
+            ),
+        ]
+        after = [
+            ModelState(
+                "testapp",
+                "Book",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("author", EmbeddedModelArrayField("testapp.author")),
+                ],
+            ),
+            ModelState(
+                "testapp",
+                "Author",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("biography", models.TextField()),
+                    ("name", models.CharField(max_length=10)),
+                ],
+                {"managed": False},
+            ),
+        ]
+        changes = self.get_changes(before, after)
+        self.assertEqual(mocked_ask_method.call_count, 2)
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(changes, "testapp", 0, ["AddField", "AddField"])

--- a/tests/migrations_/autodetector/test_embedded_model_field.py
+++ b/tests/migrations_/autodetector/test_embedded_model_field.py
@@ -1,0 +1,1264 @@
+from unittest import mock
+
+from django.db import models
+from django.db.migrations.questioner import MigrationQuestioner
+from django.db.migrations.state import ModelState
+
+from django_mongodb_backend.fields import EmbeddedModelField, ObjectIdAutoField
+
+from .base import BaseAutodetectorTests
+
+
+class EmbeddedModelFieldAutodetectorTests(BaseAutodetectorTests):
+    """Test the autodetector with EmbeddedModelField."""
+
+    def test_add_embedded_field(self):
+        """Detection of new embedded fields (Author.age)."""
+        changes = self.get_changes(
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=200)),
+                        ("author", EmbeddedModelField("testapp.author")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=10)),
+                    ],
+                    {"managed": False},
+                ),
+            ],
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=200)),
+                        ("author", EmbeddedModelField("testapp.author")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=10)),
+                        ("age", models.IntegerField()),
+                    ],
+                    {"managed": False},
+                ),
+            ],
+        )
+        # Right number/type of migrations?
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(changes, "testapp", 0, ["AddField", "AddEmbeddedField"])
+        self.assertOperationAttributes(
+            changes,
+            "testapp",
+            0,
+            1,
+            model_name="book",
+            name="author.age",
+        )
+
+    def test_add_embedded_field_db_column(self):
+        """
+        AddEmbeddedField's name uses each field's db_column in embedded paths.
+        """
+        changes = self.get_changes(
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=200)),
+                        ("author", EmbeddedModelField("testapp.author", db_column="the_author")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=10)),
+                    ],
+                    {"managed": False},
+                ),
+            ],
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=200)),
+                        ("author", EmbeddedModelField("testapp.author", db_column="the_author")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=10)),
+                        ("age", models.IntegerField(db_column="the_age")),
+                    ],
+                    {"managed": False},
+                ),
+            ],
+        )
+        # Right number/type of migrations?
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(changes, "testapp", 0, ["AddField", "AddEmbeddedField"])
+        self.assertOperationAttributes(
+            changes,
+            "testapp",
+            0,
+            1,
+            model_name="book",
+            name="the_author.the_age",
+        )
+
+    @mock.patch(
+        "django.db.migrations.questioner.MigrationQuestioner.ask_not_null_addition",
+        side_effect=AssertionError("Should not have prompted for not null addition"),
+    )
+    def test_add_date_fields_with_auto_now_not_asking_for_default(self, mocked_ask_method):
+        changes = self.get_changes(
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=200)),
+                        ("author", EmbeddedModelField("testapp.author")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=10)),
+                    ],
+                    {"managed": False},
+                ),
+            ],
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=200)),
+                        ("author", EmbeddedModelField("testapp.author")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=10)),
+                        ("date", models.DateField(auto_now=True)),
+                        ("datetime", models.DateTimeField(auto_now=True)),
+                        ("time", models.TimeField(auto_now=True)),
+                    ],
+                    {"managed": False},
+                ),
+            ],
+        )
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(
+            changes, "testapp", 0, ["AddField"] * 3 + ["AddEmbeddedField"] * 3
+        )
+        self.assertOperationAttributes(changes, "testapp", 0, 0, name="date", preserve_default=True)
+        self.assertOperationFieldAttributes(changes, "testapp", 0, 0, auto_now=True)
+        self.assertOperationFieldAttributes(changes, "testapp", 0, 1, auto_now=True)
+        self.assertOperationFieldAttributes(changes, "testapp", 0, 2, auto_now=True)
+
+    @mock.patch(
+        "django.db.migrations.questioner.MigrationQuestioner.ask_not_null_addition",
+        side_effect=AssertionError("Should not have prompted for not null addition"),
+    )
+    def test_add_date_fields_with_auto_now_add_not_asking_for_null_addition(
+        self, mocked_ask_method
+    ):
+        changes = self.get_changes(
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=200)),
+                        ("author", EmbeddedModelField("testapp.author")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=10)),
+                    ],
+                    {"managed": False},
+                ),
+            ],
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=200)),
+                        ("author", EmbeddedModelField("testapp.author")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=10)),
+                        ("date", models.DateField(auto_now_add=True)),
+                        ("datetime", models.DateTimeField(auto_now_add=True)),
+                        ("time", models.TimeField(auto_now_add=True)),
+                    ],
+                    {"managed": False},
+                ),
+            ],
+        )
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(
+            changes, "testapp", 0, ["AddField"] * 3 + ["AddEmbeddedField"] * 3
+        )
+        self.assertOperationAttributes(
+            changes, "testapp", 0, 0, name="date", preserve_default=False
+        )
+        self.assertOperationAttributes(
+            changes, "testapp", 0, 1, name="datetime", preserve_default=False
+        )
+        self.assertOperationAttributes(
+            changes, "testapp", 0, 2, name="time", preserve_default=False
+        )
+        self.assertOperationAttributes(
+            changes, "testapp", 0, 3, name="author.date", preserve_default=False
+        )
+        self.assertOperationAttributes(
+            changes, "testapp", 0, 4, name="author.datetime", preserve_default=False
+        )
+        self.assertOperationAttributes(
+            changes, "testapp", 0, 5, name="author.time", preserve_default=False
+        )
+        self.assertOperationFieldAttributes(changes, "testapp", 0, 0, auto_now_add=True)
+        self.assertOperationFieldAttributes(changes, "testapp", 0, 1, auto_now_add=True)
+        self.assertOperationFieldAttributes(changes, "testapp", 0, 2, auto_now_add=True)
+        self.assertOperationFieldAttributes(changes, "testapp", 0, 3, auto_now_add=True)
+        self.assertOperationFieldAttributes(changes, "testapp", 0, 4, auto_now_add=True)
+        self.assertOperationFieldAttributes(changes, "testapp", 0, 5, auto_now_add=True)
+
+    @mock.patch("django.db.migrations.questioner.MigrationQuestioner.ask_auto_now_add_addition")
+    def test_add_date_fields_with_auto_now_add_asking_for_default(self, mocked_ask_method):
+        changes = self.get_changes(
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=200)),
+                        ("author", EmbeddedModelField("testapp.author")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=10)),
+                    ],
+                    {"managed": False},
+                ),
+            ],
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=200)),
+                        ("author", EmbeddedModelField("testapp.author")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=10)),
+                        ("date", models.DateField(auto_now_add=True)),
+                        ("datetime", models.DateTimeField(auto_now_add=True)),
+                        ("time", models.TimeField(auto_now_add=True)),
+                    ],
+                    {"managed": False},
+                ),
+            ],
+        )
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(
+            changes, "testapp", 0, ["AddField"] * 3 + ["AddEmbeddedField"] * 3
+        )
+        self.assertOperationAttributes(
+            changes, "testapp", 0, 0, name="date", preserve_default=False
+        )
+        self.assertOperationAttributes(
+            changes, "testapp", 0, 1, name="datetime", preserve_default=False
+        )
+        self.assertOperationAttributes(
+            changes, "testapp", 0, 2, name="time", preserve_default=False
+        )
+        self.assertOperationFieldAttributes(changes, "testapp", 0, 0, auto_now_add=True)
+        self.assertOperationFieldAttributes(changes, "testapp", 0, 1, auto_now_add=True)
+        self.assertOperationFieldAttributes(changes, "testapp", 0, 2, auto_now_add=True)
+        self.assertEqual(mocked_ask_method.call_count, 6)
+
+    def test_add_nested_embedded_field(self):
+        """Detection of new nested embedded fields (Book.author.bio.title)."""
+        changes = self.get_changes(
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=200)),
+                        ("author", EmbeddedModelField("testapp.author")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=10)),
+                        ("bio", EmbeddedModelField("testapp.bio")),
+                    ],
+                    {"managed": False},
+                ),
+                ModelState(
+                    "testapp",
+                    "Bio",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                    ],
+                    {"managed": False},
+                ),
+            ],
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=200)),
+                        ("author", EmbeddedModelField("testapp.author")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=10)),
+                        ("bio", EmbeddedModelField("testapp.bio")),
+                    ],
+                    {"managed": False},
+                ),
+                ModelState(
+                    "testapp",
+                    "Bio",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("title", models.CharField(max_length=10)),  # Added
+                    ],
+                    {"managed": False},
+                ),
+            ],
+        )
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(changes, "testapp", 0, ["AddField", "AddEmbeddedField"])
+        self.assertOperationAttributes(changes, "testapp", 0, 0, model_name="bio", name="title")
+        self.assertOperationAttributes(
+            changes, "testapp", 0, 1, model_name="book", name="author.bio.title"
+        )
+
+    def test_add_embedded_model_field(self):
+        """Detection of new embedded model fields (Book.author)."""
+        changes = self.get_changes(
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=200)),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=10)),
+                    ],
+                    {"managed": False},
+                ),
+            ],
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=200)),
+                        ("author", EmbeddedModelField("testapp.author")),  # Added
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=10)),
+                    ],
+                    {"managed": False},
+                ),
+            ],
+        )
+        self.assertNumberMigrations(changes, "testapp", 1)
+        # Generates only AddField for the new model and not an AddEmbeddedField
+        # for each subfield.
+        self.assertOperationTypes(changes, "testapp", 0, ["AddField"])
+        self.assertOperationAttributes(changes, "testapp", 0, 0, model_name="book", name="author")
+
+    def test_add_nested_embedded_model_field(self):
+        """Detection of new embedded model fields (Book.author)."""
+        changes = self.get_changes(
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=200)),
+                        ("author", EmbeddedModelField("testapp.author")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=10)),
+                    ],
+                    {"managed": False},
+                ),
+                ModelState(
+                    "testapp",
+                    "Bio",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("title", models.CharField(max_length=10)),
+                    ],
+                    {"managed": False},
+                ),
+            ],
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=200)),
+                        ("author", EmbeddedModelField("testapp.author")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=10)),
+                        ("bio", EmbeddedModelField("testapp.bio")),  # Added
+                    ],
+                    {"managed": False},
+                ),
+                ModelState(
+                    "testapp",
+                    "Bio",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("title", models.CharField(max_length=10)),
+                    ],
+                    {"managed": False},
+                ),
+            ],
+        )
+        self.assertNumberMigrations(changes, "testapp", 1)
+        # Generates only AddEmbeddedField for the author.bio and not an
+        # AddEmbeddedField for each field of Bio.
+        self.assertOperationTypes(changes, "testapp", 0, ["AddField", "AddEmbeddedField"])
+        self.assertOperationAttributes(changes, "testapp", 0, 0, model_name="author", name="bio")
+        self.assertOperationAttributes(
+            changes, "testapp", 0, 1, model_name="book", name="author.bio"
+        )
+
+    def test_remove_embedded_field(self):
+        """Tests autodetection of removed fields."""
+        changes = self.get_changes(
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=200)),
+                        ("author", EmbeddedModelField("testapp.author")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=10)),
+                    ],
+                    {"managed": False},
+                ),
+            ],
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=200)),
+                        ("author", EmbeddedModelField("testapp.author")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        # Removed name
+                    ],
+                    {"managed": False},
+                ),
+            ],
+        )
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(changes, "testapp", 0, ["RemoveField", "RemoveEmbeddedField"])
+        self.assertOperationAttributes(changes, "testapp", 0, 0, name="name")
+        self.assertOperationAttributes(changes, "testapp", 0, 1, name="author.name")
+
+    def test_remove_nested_embedded_field(self):
+        """
+        Detection of removed nested embedded fields (Book.author.bio.title).
+        """
+        changes = self.get_changes(
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=200)),
+                        ("author", EmbeddedModelField("testapp.author")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=10)),
+                        ("bio", EmbeddedModelField("testapp.bio")),
+                    ],
+                    {"managed": False},
+                ),
+                ModelState(
+                    "testapp",
+                    "Bio",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("title", models.CharField(max_length=10)),
+                    ],
+                    {"managed": False},
+                ),
+            ],
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=200)),
+                        ("author", EmbeddedModelField("testapp.author")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=10)),
+                        ("bio", EmbeddedModelField("testapp.bio")),
+                    ],
+                    {"managed": False},
+                ),
+                ModelState(
+                    "testapp",
+                    "Bio",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        # Removed title
+                    ],
+                    {"managed": False},
+                ),
+            ],
+        )
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(changes, "testapp", 0, ["RemoveField", "RemoveEmbeddedField"])
+        self.assertOperationAttributes(changes, "testapp", 0, 0, model_name="bio", name="title")
+        self.assertOperationAttributes(
+            changes, "testapp", 0, 1, model_name="book", name="author.bio.title"
+        )
+
+    def test_alter_embedded_field(self):
+        """Detection of db_column change on an embedded field."""
+        changes = self.get_changes(
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=200)),
+                        ("author", EmbeddedModelField("testapp.author")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=10)),
+                    ],
+                    {"managed": False},
+                ),
+            ],
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=200)),
+                        ("author", EmbeddedModelField("testapp.author")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=10, db_column="the_name")),
+                    ],
+                    {"managed": False},
+                ),
+            ],
+        )
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(changes, "testapp", 0, ["AlterField", "AlterEmbeddedField"])
+        self.assertOperationAttributes(changes, "testapp", 0, 0, model_name="author", name="name")
+        self.assertOperationAttributes(
+            changes, "testapp", 0, 1, model_name="book", name="author.name"
+        )
+
+    def test_rename_embedded_field(self):
+        """
+        Detection of renamed embedded fields (Author.name -> Author.full_name).
+        """
+        changes = self.get_changes(
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=200)),
+                        ("author", EmbeddedModelField("testapp.author")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=10)),
+                    ],
+                    {"managed": False},
+                ),
+            ],
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=200)),
+                        ("author", EmbeddedModelField("testapp.author")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("full_name", models.CharField(max_length=10)),
+                    ],
+                    {"managed": False},
+                ),
+            ],
+            MigrationQuestioner({"ask_rename": True}),
+        )
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(changes, "testapp", 0, ["RenameField", "RenameEmbeddedField"])
+        self.assertOperationAttributes(
+            changes, "testapp", 0, 0, model_name="author", old_name="name", new_name="full_name"
+        )
+        self.assertOperationAttributes(
+            changes,
+            "testapp",
+            0,
+            1,
+            model_name="book",
+            old_name="author.name",
+            new_name="author.full_name",
+        )
+
+    def test_alter_embbedded_field_max_length(self):
+        """AlterEmbeddedField isn't generated for max_length changes."""
+        changes = self.get_changes(
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=200)),
+                        ("author", EmbeddedModelField("testapp.author")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=10)),
+                    ],
+                    {"managed": False},
+                ),
+            ],
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=200)),
+                        ("author", EmbeddedModelField("testapp.author")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=15)),  # max_length increased
+                    ],
+                    {"managed": False},
+                ),
+            ],
+        )
+        self.assertNumberMigrations(changes, "testapp", 1)
+        # No AlterEmbeddedField operation generated.
+        self.assertOperationTypes(changes, "testapp", 0, ["AlterField"])
+        self.assertOperationAttributes(changes, "testapp", 0, 0, model_name="author", name="name")
+
+    @mock.patch(
+        "django.db.migrations.questioner.MigrationQuestioner.ask_not_null_alteration",
+        side_effect=AssertionError("Should not have prompted for not null alteration"),
+    )
+    def test_alter_field_to_not_null_with_default(self, mocked_ask_method):
+        """
+        Nullable to non-nullable alteration with a default doesn't prompt.
+        """
+        before = [
+            ModelState(
+                "testapp",
+                "Book",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("author", EmbeddedModelField("testapp.author")),
+                ],
+            ),
+            ModelState(
+                "testapp",
+                "Author",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("name", models.CharField(max_length=10, null=True)),
+                ],
+                {"managed": False},
+            ),
+        ]
+        after = [
+            ModelState(
+                "testapp",
+                "Book",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("author", EmbeddedModelField("testapp.author")),
+                ],
+            ),
+            ModelState(
+                "testapp",
+                "Author",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("name", models.CharField(max_length=10, default="Ada Lovelace")),
+                ],
+                {"managed": False},
+            ),
+        ]
+        changes = self.get_changes(before, after)
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(changes, "testapp", 0, ["AlterField"])
+        self.assertOperationAttributes(changes, "testapp", 0, 0, name="name", preserve_default=True)
+        self.assertOperationFieldAttributes(changes, "testapp", 0, 0, default="Ada Lovelace")
+
+    @mock.patch(
+        "django.db.migrations.questioner.MigrationQuestioner.ask_not_null_alteration",
+        return_value=models.NOT_PROVIDED,
+    )
+    def test_alter_field_to_not_null_without_default(self, mocked_ask_method):
+        """
+        Nullable to non-nullable alteration without a default prompts once.
+        """
+        before = [
+            ModelState(
+                "testapp",
+                "Book",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("author", EmbeddedModelField("testapp.author")),
+                ],
+            ),
+            ModelState(
+                "testapp",
+                "Author",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("name", models.CharField(max_length=10, null=True)),
+                ],
+                {"managed": False},
+            ),
+        ]
+        after = [
+            ModelState(
+                "testapp",
+                "Book",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("author", EmbeddedModelField("testapp.author")),
+                ],
+            ),
+            ModelState(
+                "testapp",
+                "Author",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("name", models.CharField(max_length=10)),
+                ],
+                {"managed": False},
+            ),
+        ]
+        changes = self.get_changes(before, after)
+        self.assertEqual(mocked_ask_method.call_count, 1)
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(changes, "testapp", 0, ["AlterField"])
+        self.assertOperationAttributes(changes, "testapp", 0, 0, name="name", preserve_default=True)
+        self.assertOperationFieldAttributes(changes, "testapp", 0, 0, default=models.NOT_PROVIDED)
+
+    @mock.patch(
+        "django.db.migrations.questioner.MigrationQuestioner.ask_not_null_alteration",
+        return_value="Some Name",
+    )
+    def test_alter_field_to_not_null_oneoff_default(self, mocked_ask_method):
+        """Nullable to non-nullable alteration with a one-off default."""
+        before = [
+            ModelState(
+                "testapp",
+                "Book",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("author", EmbeddedModelField("testapp.author")),
+                ],
+            ),
+            ModelState(
+                "testapp",
+                "Author",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("name", models.CharField(max_length=10, null=True)),
+                ],
+                {"managed": False},
+            ),
+        ]
+        after = [
+            ModelState(
+                "testapp",
+                "Book",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("author", EmbeddedModelField("testapp.author")),
+                ],
+            ),
+            ModelState(
+                "testapp",
+                "Author",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("name", models.CharField(max_length=10)),
+                ],
+                {"managed": False},
+            ),
+        ]
+        changes = self.get_changes(before, after)
+        self.assertEqual(mocked_ask_method.call_count, 1)
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(changes, "testapp", 0, ["AlterField"])
+        self.assertOperationAttributes(
+            changes, "testapp", 0, 0, name="name", preserve_default=False
+        )
+        self.assertOperationFieldAttributes(changes, "testapp", 0, 0, default="Some Name")
+
+    def test_rename_field(self):
+        """
+        Renaming a field in an embedded model generates RenameEmbeddedField.
+        """
+        changes = self.get_changes(
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("author", EmbeddedModelField("testapp.author")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=10)),
+                    ],
+                    {"managed": False},
+                ),
+            ],
+            [
+                ModelState(
+                    "testapp",
+                    "Book",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("author", EmbeddedModelField("testapp.author")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Author",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("names", models.CharField(max_length=10)),
+                    ],
+                    {"managed": False},
+                ),
+            ],
+            MigrationQuestioner({"ask_rename": True}),
+        )
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(changes, "testapp", 0, ["RenameField", "RenameEmbeddedField"])
+        self.assertOperationAttributes(
+            changes, "testapp", 0, 0, model_name="author", old_name="name", new_name="names"
+        )
+        self.assertOperationAttributes(
+            changes,
+            "testapp",
+            0,
+            1,
+            model_name="book",
+            old_name="author.name",
+            new_name="author.names",
+        )
+
+    def test_rename_field_preserved_db_column(self):
+        """
+        RenameField is used if a field is renamed and db_column equal to the
+        old field's column is added. RenameEmbeddedField is also generated
+        since the attribute path changes even though the column path doesn't.
+        """
+        before = [
+            ModelState(
+                "testapp",
+                "Book",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("author", EmbeddedModelField("testapp.author")),
+                ],
+            ),
+            ModelState(
+                "testapp",
+                "Author",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("field", models.IntegerField()),
+                ],
+                {"managed": False},
+            ),
+        ]
+        after = [
+            ModelState(
+                "testapp",
+                "Book",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("author", EmbeddedModelField("testapp.author")),
+                ],
+            ),
+            ModelState(
+                "testapp",
+                "Author",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("renamed_field", models.IntegerField(db_column="field")),
+                ],
+                {"managed": False},
+            ),
+        ]
+        changes = self.get_changes(before, after, MigrationQuestioner({"ask_rename": True}))
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(
+            changes, "testapp", 0, ["AlterField", "RenameField", "RenameEmbeddedField"]
+        )
+        self.assertOperationAttributes(
+            changes,
+            "testapp",
+            0,
+            0,
+            model_name="author",
+            name="field",
+        )
+        self.assertEqual(
+            changes["testapp"][0].operations[0].field.deconstruct(),
+            (
+                "field",
+                "django.db.models.IntegerField",
+                [],
+                {"db_column": "field"},
+            ),
+        )
+        self.assertOperationAttributes(
+            changes,
+            "testapp",
+            0,
+            1,
+            model_name="author",
+            old_name="field",
+            new_name="renamed_field",
+        )
+        self.assertOperationAttributes(
+            changes,
+            "testapp",
+            0,
+            2,
+            model_name="book",
+            old_name="author.field",
+            new_name="author.renamed_field",
+        )
+
+    def test_add_field_with_default(self):
+        """
+        Adding a field with a default to an embedded model generates
+        AddEmbeddedField.
+        """
+        before = [
+            ModelState(
+                "testapp",
+                "Book",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("author", EmbeddedModelField("testapp.author")),
+                ],
+            ),
+            ModelState(
+                "testapp",
+                "Author",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                ],
+                {"managed": False},
+            ),
+        ]
+        after = [
+            ModelState(
+                "testapp",
+                "Book",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("author", EmbeddedModelField("testapp.author")),
+                ],
+            ),
+            ModelState(
+                "testapp",
+                "Author",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("name", models.CharField(max_length=10, default="Ada Lovelace")),
+                ],
+                {"managed": False},
+            ),
+        ]
+        changes = self.get_changes(before, after)
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(changes, "testapp", 0, ["AddField", "AddEmbeddedField"])
+        self.assertOperationAttributes(changes, "testapp", 0, 0, name="name")
+
+    @mock.patch(
+        "django.db.migrations.questioner.MigrationQuestioner.ask_not_null_addition",
+        side_effect=AssertionError("Should not have prompted for not null addition"),
+    )
+    def test_add_blank_textfield_and_charfield(self, mocked_ask_method):
+        """
+        Adding a NOT NULL and blank CharField or TextField without default
+        should not prompt for a default.
+        """
+        before = [
+            ModelState(
+                "testapp",
+                "Book",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("author", EmbeddedModelField("testapp.author")),
+                ],
+            ),
+            ModelState(
+                "testapp",
+                "Author",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                ],
+                {"managed": False},
+            ),
+        ]
+        after = [
+            ModelState(
+                "testapp",
+                "Book",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("author", EmbeddedModelField("testapp.author")),
+                ],
+            ),
+            ModelState(
+                "testapp",
+                "Author",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("biography", models.TextField(blank=True)),
+                    ("name", models.CharField(max_length=10, blank=True)),
+                ],
+                {"managed": False},
+            ),
+        ]
+        changes = self.get_changes(before, after)
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(
+            changes, "testapp", 0, ["AddField", "AddField", "AddEmbeddedField", "AddEmbeddedField"]
+        )
+
+    @mock.patch("django.db.migrations.questioner.MigrationQuestioner.ask_not_null_addition")
+    def test_add_non_blank_textfield_and_charfield(self, mocked_ask_method):
+        """
+        Adding a NOT NULL and non-blank CharField or TextField without default
+        should prompt for a default (once per AddField and once per
+        AddEmbeddedField).
+        """
+        before = [
+            ModelState(
+                "testapp",
+                "Book",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("author", EmbeddedModelField("testapp.author")),
+                ],
+            ),
+            ModelState(
+                "testapp",
+                "Author",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                ],
+                {"managed": False},
+            ),
+        ]
+        after = [
+            ModelState(
+                "testapp",
+                "Book",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("author", EmbeddedModelField("testapp.author")),
+                ],
+            ),
+            ModelState(
+                "testapp",
+                "Author",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("biography", models.TextField()),
+                    ("name", models.CharField(max_length=10)),
+                ],
+                {"managed": False},
+            ),
+        ]
+        changes = self.get_changes(before, after)
+        self.assertEqual(mocked_ask_method.call_count, 4)
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(
+            changes, "testapp", 0, ["AddField", "AddField", "AddEmbeddedField", "AddEmbeddedField"]
+        )

--- a/tests/migrations_/autodetector/test_embedded_model_field.py
+++ b/tests/migrations_/autodetector/test_embedded_model_field.py
@@ -331,7 +331,7 @@ class EmbeddedModelFieldAutodetectorTests(BaseAutodetectorTests):
         self.assertOperationFieldAttributes(changes, "testapp", 0, 0, auto_now_add=True)
         self.assertOperationFieldAttributes(changes, "testapp", 0, 1, auto_now_add=True)
         self.assertOperationFieldAttributes(changes, "testapp", 0, 2, auto_now_add=True)
-        self.assertEqual(mocked_ask_method.call_count, 6)
+        self.assertEqual(mocked_ask_method.call_count, 3)
 
     def test_add_nested_embedded_field(self):
         """Detection of new nested embedded fields (Book.author.bio.title)."""
@@ -1215,8 +1215,7 @@ class EmbeddedModelFieldAutodetectorTests(BaseAutodetectorTests):
     def test_add_non_blank_textfield_and_charfield(self, mocked_ask_method):
         """
         Adding a NOT NULL and non-blank CharField or TextField without default
-        should prompt for a default (once per AddField and once per
-        AddEmbeddedField).
+        prompts once per field; AddEmbeddedField reuses the same default.
         """
         before = [
             ModelState(
@@ -1257,7 +1256,7 @@ class EmbeddedModelFieldAutodetectorTests(BaseAutodetectorTests):
             ),
         ]
         changes = self.get_changes(before, after)
-        self.assertEqual(mocked_ask_method.call_count, 4)
+        self.assertEqual(mocked_ask_method.call_count, 2)
         self.assertNumberMigrations(changes, "testapp", 1)
         self.assertOperationTypes(
             changes, "testapp", 0, ["AddField", "AddField", "AddEmbeddedField", "AddEmbeddedField"]

--- a/tests/migrations_/operations/test_embedded_model_array_field.py
+++ b/tests/migrations_/operations/test_embedded_model_array_field.py
@@ -1,0 +1,200 @@
+from django.db import connection, migrations, models
+from django.db.migrations.state import ProjectState
+from django.test.utils import CaptureQueriesContext
+from migrations.test_base import OperationTestBase
+
+from django_mongodb_backend.db.migrations.operations import (
+    AddEmbeddedField,
+    AlterEmbeddedField,
+    RemoveEmbeddedField,
+    RenameEmbeddedField,
+)
+from django_mongodb_backend.fields import (
+    EmbeddedModelArrayField,
+    ObjectIdAutoField,
+)
+
+
+class EmbeddedModelArrayFieldOperationTests(OperationTestBase):
+    """Tests for embedded field operations on EmbeddedModelArrayField."""
+
+    available_apps = ["migrations_"]
+
+    def set_up_test_model(self, app_label):
+        """Create Book with an EmbeddedModelArrayField pointing to Review."""
+        operations = [
+            migrations.CreateModel(
+                "Review",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("body", models.TextField()),
+                ],
+                options={},
+            ),
+            migrations.CreateModel(
+                "Book",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("title", models.CharField(max_length=100)),
+                    ("reviews", EmbeddedModelArrayField(f"{app_label}.review")),
+                ],
+                options={},
+            ),
+        ]
+        return self.apply_operations(app_label, ProjectState(), operations)
+
+    def test_add_embedded_field(self):
+        """AddEmbeddedField sets the default on all existing array elements."""
+        app_label = "test_arademfl"
+        new_field = models.IntegerField(null=True, default=50)
+        operation = AddEmbeddedField("Book", "reviews.$[].rating", new_field)
+        self.assertEqual(operation.describe(), "Add embedded field reviews.$[].rating to Book")
+
+        initial_state = self.set_up_test_model(app_label)
+        Book = initial_state.apps.get_model(app_label, "Book")
+        Review = initial_state.apps.get_model(app_label, "Review")
+        book = Book.objects.create(
+            title="Moby Dick",
+            reviews=[Review(body="Classic!")],
+        )
+        # Add field to the state without touching the database.
+        new_state = self.apply_operations(
+            app_label,
+            initial_state,
+            operations=[
+                migrations.AddField("Review", "rating", new_field, preserve_default=False),
+                operation,
+            ],
+        )
+        Book = new_state.apps.get_model(app_label, "Book")
+        book = Book.objects.get(pk=book.pk)
+        self.assertEqual(book.reviews[0].rating, 50)
+
+        # Reversal removes the key from existing array elements.
+        with connection.schema_editor() as editor:
+            operation.database_backwards(app_label, editor, new_state, initial_state)
+
+        # TODO:
+        # book.refresh_from_db()
+        # self.assertEqual(book.reviews[0].body, "Classic!")
+        # self.assertFalse(hasattr(book.reviews[0], "rating"))
+
+    def test_remove_embedded_field(self):
+        """
+        RemoveEmbeddedField issues $unset with the $[] positional
+        operator.
+        """
+        app_label = "test_arremfl"
+        initial_state = self.set_up_test_model(app_label)
+        # Extend the state with a rating field without touching the database.
+        pre_state = self.apply_operations(
+            app_label,
+            initial_state,
+            operations=[
+                migrations.AddField(
+                    "Review",
+                    "rating",
+                    models.IntegerField(null=True),
+                    preserve_default=False,
+                ),
+                AddEmbeddedField("Book", "reviews.$[].rating", models.IntegerField(null=True)),
+            ],
+        )
+        operation = RemoveEmbeddedField("Book", "reviews.rating")
+        self.assertEqual(operation.describe(), "Remove embedded field reviews.rating from Book")
+        new_state = pre_state.clone()
+        operation.state_forwards(app_label, new_state)
+
+        with (
+            connection.schema_editor() as editor,
+            CaptureQueriesContext(connection) as ctx,
+        ):
+            operation.database_forwards(app_label, editor, pre_state, new_state)
+        self.assertIn(
+            "'$unset': {'reviews.$[].rating': ''}",
+            ctx.captured_queries[-1]["sql"],
+        )
+
+        # Reversal re-adds the field to existing array elements.
+        with (
+            connection.schema_editor() as editor,
+            CaptureQueriesContext(connection) as ctx,
+        ):
+            operation.database_backwards(app_label, editor, new_state, pre_state)
+        self.assertIn(
+            "'$set': {'reviews.$[].rating':",
+            ctx.captured_queries[-1]["sql"],
+        )
+
+    def test_alter_embedded_field(self):
+        """
+        AlterEmbeddedField uses a $map pipeline (not $rename) for array
+        paths.
+        """
+        app_label = "test_araltemfl"
+        new_field = models.TextField(db_column="the_body")
+        operation = AlterEmbeddedField("Book", "reviews.body", new_field)
+        self.assertEqual(operation.describe(), "Alter embedded field reviews.body on Book")
+
+        initial_state = self.set_up_test_model(app_label)
+        new_state = initial_state.clone()
+        migrations.AlterField("Review", "body", new_field).state_forwards(app_label, new_state)
+
+        with (
+            connection.schema_editor() as editor,
+            CaptureQueriesContext(connection) as ctx,
+        ):
+            operation.database_forwards(app_label, editor, initial_state, new_state)
+        sql = ctx.captured_queries[-1]["sql"]
+        # Must use $map (not $rename) since $rename doesn't support $[] paths.
+        self.assertIn("$map", sql)
+        self.assertNotIn("$rename", sql)
+        self.assertIn("'input': '$reviews'", sql)
+        self.assertIn("'field': 'body'", sql)
+        self.assertIn("'the_body': '$$item.body'", sql)
+
+        # Reversal renames back.
+        with (
+            connection.schema_editor() as editor,
+            CaptureQueriesContext(connection) as ctx,
+        ):
+            operation.database_backwards(app_label, editor, new_state, initial_state)
+        sql = ctx.captured_queries[-1]["sql"]
+        self.assertIn("$map", sql)
+        self.assertIn("'field': 'the_body'", sql)
+        self.assertIn("'body': '$$item.the_body'", sql)
+
+    def test_rename_embedded_field(self):
+        """RenameEmbeddedField uses a $map pipeline for array paths."""
+        app_label = "test_arrnemfl"
+        operation = RenameEmbeddedField("Book", "reviews.body", "reviews.content")
+        self.assertEqual(
+            operation.describe(),
+            "Rename embedded field reviews.body on Book to reviews.content",
+        )
+
+        initial_state = self.set_up_test_model(app_label)
+        new_state = initial_state.clone()
+        migrations.RenameField("Review", "body", "content").state_forwards(app_label, new_state)
+
+        with (
+            connection.schema_editor() as editor,
+            CaptureQueriesContext(connection) as ctx,
+        ):
+            operation.database_forwards(app_label, editor, initial_state, new_state)
+        sql = ctx.captured_queries[-1]["sql"]
+        self.assertIn("$map", sql)
+        self.assertNotIn("$rename", sql)
+        self.assertIn("'field': 'body'", sql)
+        self.assertIn("'content': '$$item.body'", sql)
+
+        # Reversal renames back.
+        with (
+            connection.schema_editor() as editor,
+            CaptureQueriesContext(connection) as ctx,
+        ):
+            operation.database_backwards(app_label, editor, new_state, initial_state)
+        sql = ctx.captured_queries[-1]["sql"]
+        self.assertIn("$map", sql)
+        self.assertIn("'field': 'content'", sql)
+        self.assertIn("'body': '$$item.content'", sql)

--- a/tests/migrations_/operations/test_embedded_model_field.py
+++ b/tests/migrations_/operations/test_embedded_model_field.py
@@ -1,0 +1,227 @@
+from django.db import connection, migrations, models
+from django.db.migrations.state import ProjectState
+from django.test.utils import CaptureQueriesContext
+from migrations.test_base import OperationTestBase
+
+from django_mongodb_backend.db.migrations.operations import (
+    AddEmbeddedField,
+    AlterEmbeddedField,
+    RemoveEmbeddedField,
+    RenameEmbeddedField,
+)
+from django_mongodb_backend.fields import EmbeddedModelField, ObjectIdAutoField
+
+
+class EmbeddedModelFieldOperationTests(OperationTestBase):
+    """
+    Tests running the operations and making sure they do what they say they do.
+    Each test looks at their state changing, and then their database operation,
+    both forwards and backwards.
+    """
+
+    available_apps = ["migrations_"]
+
+    def set_up_test_model(self, app_label):
+        """Create a test model state and database table."""
+        # Make the "current" state.
+        operations = [
+            migrations.CreateModel(
+                "Author",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("name", models.CharField(max_length=100)),
+                ],
+                options={},
+            ),
+            migrations.CreateModel(
+                "Book",
+                [
+                    ("id", ObjectIdAutoField(primary_key=True)),
+                    ("name", models.CharField(max_length=100)),
+                    ("author", EmbeddedModelField("Author")),
+                ],
+                options={},
+            ),
+        ]
+        return self.apply_operations(app_label, ProjectState(), operations)
+
+    def test_add_embedded_field(self):
+        """Test the AddEmbeddedField operation."""
+        app_label = "test_ademfl"
+        # Test the state alteration
+        new_field = models.IntegerField(null=True, default=50)
+        operation = AddEmbeddedField(
+            "Book",
+            "author.age",
+            new_field,
+        )
+        self.assertEqual(operation.describe(), "Add embedded field author.age to Book")
+        self.assertEqual(
+            operation.formatted_description(), "+ Add embedded field author.age to Book"
+        )
+        self.assertEqual(operation.migration_name_fragment, "book_author.age")
+
+        initial_state = self.set_up_test_model(app_label)
+        # Create initial data
+        Book = initial_state.apps.get_model(app_label, "Book")
+        Author = initial_state.apps.get_model(app_label, "Author")
+        book = Book.objects.create(name="Moby Dick", author=Author(name="Melville"))
+
+        new_state = self.apply_operations(
+            app_label,
+            initial_state,
+            operations=[
+                migrations.AddField(
+                    "Author",
+                    "age",
+                    new_field,
+                    preserve_default=False,
+                ),
+                operation,
+            ],
+        )
+        field = new_state.models[app_label, "author"].fields["age"]
+        self.assertEqual(field.default, models.NOT_PROVIDED)
+
+        Book = new_state.apps.get_model(app_label, "Book")
+        Author = new_state.apps.get_model(app_label, "Author")
+        book = Book.objects.get(pk=book.pk)
+        # Value is populated on existing columns.
+        self.assertEqual(book.author.age, 50)
+        # Reversal removes key in exiting documents.
+        with connection.schema_editor() as editor:
+            operation.database_backwards(app_label, editor, new_state, initial_state)
+
+        b1 = Book.objects.get(pk=book.pk)
+        self.assertEqual(b1.author.age, models.NOT_PROVIDED)
+        # And deconstruction
+        name, args, kwargs = operation.deconstruct()
+        self.assertEqual(name, "AddEmbeddedField")
+        self.assertEqual(args, [])
+        self.assertEqual(kwargs, {"model_name": "Book", "name": "author.age", "field": new_field})
+
+    def test_alter_embedded_field(self):
+        """Test the AlterEmbeddedField operation."""
+        app_label = "test_altemfl"
+        new_field = models.CharField(max_length=100, db_column="the_name")
+        operation = AlterEmbeddedField("Book", "author.name", new_field)
+        self.assertEqual(operation.describe(), "Alter embedded field author.name on Book")
+        self.assertEqual(
+            operation.formatted_description(),
+            "~ Alter embedded field author.name on Book",
+        )
+        initial_state = self.set_up_test_model(app_label)
+        # Build the new state by updating Author.name's db_column without
+        # touching the db.
+        new_state = initial_state.clone()
+        migrations.AlterField("Author", "name", new_field).state_forwards(app_label, new_state)
+        # Test the database alteration.
+        with (
+            connection.schema_editor() as editor,
+            CaptureQueriesContext(connection) as ctx,
+        ):
+            operation.database_forwards(app_label, editor, initial_state, new_state)
+        self.assertEqual(
+            ctx.captured_queries[-1]["sql"],
+            "db.test_altemfl_book.update_many({}, {'$rename': {'author.name': 'author.the_name'}})",
+        )
+        # Test reversal.
+        with (
+            connection.schema_editor() as editor,
+            CaptureQueriesContext(connection) as ctx,
+        ):
+            operation.database_backwards(app_label, editor, new_state, initial_state)
+        self.assertEqual(
+            ctx.captured_queries[-1]["sql"],
+            "db.test_altemfl_book.update_many({}, {'$rename': {'author.the_name': 'author.name'}})",
+        )
+        # Test deconstruction.
+        name, args, kwargs = operation.deconstruct()
+        self.assertEqual(name, "AlterEmbeddedField")
+        self.assertEqual(args, [])
+        self.assertEqual(kwargs, {"model_name": "Book", "name": "author.name", "field": new_field})
+
+    def test_rename_embedded_field(self):
+        """Test the RenameEmbeddedField operation."""
+        app_label = "test_rnemfl"
+        operation = RenameEmbeddedField("Book", "author.name", "author.full_name")
+        self.assertEqual(
+            operation.describe(),
+            "Rename embedded field author.name on Book to author.full_name",
+        )
+        self.assertEqual(
+            operation.formatted_description(),
+            "~ Rename embedded field author.name on Book to author.full_name",
+        )
+        initial_state = self.set_up_test_model(app_label)
+        # Build the new state by renaming Author.name to Author.full_name
+        # without touching the db.
+        new_state = initial_state.clone()
+        migrations.RenameField("Author", "name", "full_name").state_forwards(app_label, new_state)
+        # Test the database alteration.
+        with (
+            connection.schema_editor() as editor,
+            CaptureQueriesContext(connection) as ctx,
+        ):
+            operation.database_forwards(app_label, editor, initial_state, new_state)
+        self.assertEqual(
+            ctx.captured_queries[-1]["sql"],
+            "db.test_rnemfl_book.update_many({}, {'$rename': {'author.name': 'author.full_name'}})",
+        )
+        # Test reversal.
+        with (
+            connection.schema_editor() as editor,
+            CaptureQueriesContext(connection) as ctx,
+        ):
+            operation.database_backwards(app_label, editor, new_state, initial_state)
+        self.assertEqual(
+            ctx.captured_queries[-1]["sql"],
+            "db.test_rnemfl_book.update_many({}, {'$rename': {'author.full_name': 'author.name'}})",
+        )
+        # Test deconstruction.
+        name, args, kwargs = operation.deconstruct()
+        self.assertEqual(name, "RenameEmbeddedField")
+        self.assertEqual(args, [])
+        self.assertEqual(
+            kwargs,
+            {"model_name": "Book", "old_name": "author.name", "new_name": "author.full_name"},
+        )
+
+    def test_remove_embedded_field(self):
+        """Test the RemoveEmbeddedField operation."""
+        app_label = "test_rmemfl"
+        project_state = self.set_up_test_model(app_label)
+        # Test the state alteration
+        operation = RemoveEmbeddedField("Book", "author.name")
+        self.assertEqual(operation.describe(), "Remove embedded field author.name from Book")
+        self.assertEqual(
+            operation.formatted_description(), "- Remove embedded field author.name from Book"
+        )
+        self.assertEqual(operation.migration_name_fragment, "remove_book_author.name")
+        new_state = project_state.clone()
+        operation.state_forwards(app_label, new_state)
+        # Test the database alteration
+        with (
+            connection.schema_editor() as editor,
+            CaptureQueriesContext(connection) as ctx,
+        ):
+            operation.database_forwards(app_label, editor, project_state, new_state)
+        self.assertEqual(
+            ctx.captured_queries[-1]["sql"],
+            "db.test_rmemfl_book.update_many({}, {'$unset': {'author.name': ''}})",
+        )
+        # And test reversal
+        with (
+            connection.schema_editor() as editor,
+            CaptureQueriesContext(connection) as ctx,
+        ):
+            operation.database_backwards(app_label, editor, new_state, project_state)
+        self.assertEqual(
+            ctx.captured_queries[-1]["sql"],
+            "db.test_rmemfl_book.update_many({}, [{'$set': {'author.name': None}}])",
+        )
+        # And deconstruction
+        definition = operation.deconstruct()
+        self.assertEqual(definition[0], "RemoveEmbeddedField")
+        self.assertEqual(definition[1], [])
+        self.assertEqual(definition[2], {"model_name": "Book", "name": "author.name"})


### PR DESCRIPTION
Re-opens the work from #518 on a fork branch. Original author: @timgraham.

Same commits as #518 (e5c3768), unmodified.