### PR TITLE
INTPYTHON-990 Add MongoDB nightly server variants to CI

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -249,6 +249,43 @@ buildvariants:
     tasks:
       - name: run-encryption-tests
 
+  # Variants that run against the latest MongoDB nightly server build to catch
+  # new server-side validations and behavior changes early. Scheduled daily
+  # rather than on every commit.
+  - name: tests-latest-auth-ssl
+    display_name: Run Tests Latest Auth SSL
+    run_on: rhel87-small
+    batchtime: 1440  # Daily
+    expansions:
+      MONGODB_VERSION: "latest"
+      TOPOLOGY: server
+      AUTH: "auth"
+      SSL: "ssl"
+    tasks:
+      - name: run-tests
+
+  - name: tests-latest-qe-local
+    display_name: Run Tests Latest QE local KMS
+    run_on: rhel87-small
+    batchtime: 1440  # Daily
+    expansions:
+      MONGODB_VERSION: "latest"
+      TOPOLOGY: replica_set
+      DJANGO_SETTINGS_MODULE: "encrypted_settings"
+    tasks:
+      - name: run-encryption-tests
+
+  - name: tests-latest-qe-aws
+    display_name: Run Tests Latest QE AWS KMS
+    run_on: rhel87-small
+    batchtime: 1440  # Daily
+    expansions:
+      MONGODB_VERSION: "latest"
+      TOPOLOGY: replica_set
+      DJANGO_SETTINGS_MODULE: "encrypted_aws_settings"
+    tasks:
+      - name: run-encryption-tests
+
   - name: performance-tests
     display_name: Performance Tests
     run_on:


### PR DESCRIPTION
https://jira.mongodb.org/browse/INTPYTHON-990

Adds three build variants that run against the latest MongoDB nightly server build (`MONGODB_VERSION: latest`), so new server-side validations and behavior changes surface promptly instead of only being caught by the subset of PyMongo non-standard tasks:

- `tests-latest-auth-ssl` — full unit test suite, auth + SSL
- `tests-latest-qe-local` — encryption/QE tests, local KMS
- `tests-latest-qe-aws` — encryption/QE tests, AWS KMS

All three use `batchtime: 1440` so they're scheduled at most daily on mainline rather than on every commit, per the discussion on the ticket.

Note: `batchtime` only affects mainline scheduling — these variants can still be selected in patch builds, but won't run unless chosen.