### PR TITLE
INTPYTHON-1050 Bump version to 6.1.0

### DIFF
--- a/django_mongodb_backend/__init__.py
+++ b/django_mongodb_backend/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "6.1.0.dev0"
+__version__ = "6.1.0"
 
 # Check Django compatibility before other imports which may fail if the
 # wrong version of Django is installed.

--- a/docs/releases/6.0.x.rst
+++ b/docs/releases/6.0.x.rst
@@ -2,6 +2,8 @@
 Django MongoDB Backend 6.0.x
 ============================
 
+.. _django-mongodb-backend-6.0.4:
+
 6.0.4
 =====
 

--- a/docs/releases/6.1.x.rst
+++ b/docs/releases/6.1.x.rst
@@ -5,12 +5,20 @@ Django MongoDB Backend 6.1.x
 6.1.0
 =====
 
-*Unreleased*
+*August 12, 2026*
 
-FIXME(replace x with latest version number): Initial release from the state of
-django-mongodb-backend 6.0.x.
+Initial release from the state of :ref:`django-mongodb-backend 6.0.4
+<django-mongodb-backend-6.0.4>`.
 
 Backwards incompatible changes
 ------------------------------
 
-- ...
+- Django 6.1 is now required. Django 6.0 is supported by the
+  ``django-mongodb-backend`` 6.0.x series.
+- Defining indexes and constraints on embedded models using ``unique=True``,
+  ``db_index=True``, ``Meta.constraints``, ``Meta.indexes``, and
+  ``Meta.unique_together`` is no longer supported, as per the
+  :ref:`deprecation timeline <inline-constraints-and-indexes-deprecation>`.
+  Use :class:`~django_mongodb_backend.indexes.EmbeddedFieldIndex` and
+  :class:`~django_mongodb_backend.constraints.EmbeddedFieldUniqueConstraint`
+  on the top-level model instead.


### PR DESCRIPTION
INTPYTHON-1050

## Changes in this PR

Prepares the 6.1.0 release:

- Bumps `__version__` from `6.1.0.dev0` to `6.1.0`.
- Fills in the 6.1.0 release notes, which were a placeholder: dates the release, notes that it is the initial release from the state of 6.0.4, and documents the two backwards incompatible changes (Django 6.1 is now required; inline indexes/constraints on embedded models are removed per the deprecation timeline).
- Adds a `_django-mongodb-backend-6.0.4` label in the 6.0.x notes so 6.1.0 can cross-reference it, matching the existing 5.2.3 pattern.

The only changes on `main` since 6.0.4 are the Django 6.1 update (#608) and dependabot action bumps, so there are no new-feature or bug-fix entries to add.

The `6.0.x` branch has been created at `bcd4027` (the parent of #608) to receive backports.

## Test Plan

Docs build clean with `sphinx -W` (warnings as errors), which verifies the new cross-reference resolves.

Draft until the release date is confirmed — the notes currently say *August 12, 2026*.

## Checklist

### Checklist for Author

- [x] Did you update the changelog (if necessary)?
- [ ] Is the intention of the code captured in relevant tests?
- [ ] If there are new TODOs, has a related JIRA ticket been created?

### Checklist for Reviewer

- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Have you checked for spelling & grammar errors?
- [ ] Is all relevant documentation (README or docstring) updated?