### PR TITLE
INTPYTHON-1063 Bump version to 5.2.4

### DIFF
--- a/django_mongodb_backend/__init__.py
+++ b/django_mongodb_backend/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "5.2.4.dev0"
+__version__ = "5.2.4"
 
 # Check Django compatibility before other imports which may fail if the
 # wrong version of Django is installed.

--- a/django_mongodb_backend/features.py
+++ b/django_mongodb_backend/features.py
@@ -251,6 +251,7 @@ class DatabaseFeatures(GISFeatures, BaseDatabaseFeatures):
             "queries.test_qs_combinators.QuerySetSetOperationTests.test_order_raises_on_non_selected_column",
             "queries.tests.RelatedLookupTypeTests.test_values_queryset_lookup",
             "queries.tests.ValuesSubqueryTests.test_values_in_subquery",
+            "serializers.test_deserialization.TestDeserializer.test_crafted_xml_performance",
             "sites_tests.tests.CreateDefaultSiteTests.test_no_site_id",
         },
         "Cannot use QuerySet.delete() when querying across multiple collections on MongoDB.": {

--- a/django_mongodb_backend/fields/polymorphic_embedded_model.py
+++ b/django_mongodb_backend/fields/polymorphic_embedded_model.py
@@ -20,7 +20,8 @@ class PolymorphicEmbeddedModelField(models.Field):
         Like other relational fields, each model may also be passed as a
         string.
         """
-        self.embedded_models = embedded_models
+        # For consistency, cast list to tuple, if necessary.
+        self.embedded_models = tuple(embedded_models)
         kwargs["editable"] = False
         super().__init__(*args, **kwargs)
 

--- a/django_mongodb_backend/fields/polymorphic_embedded_model_array.py
+++ b/django_mongodb_backend/fields/polymorphic_embedded_model_array.py
@@ -19,7 +19,8 @@ class PolymorphicEmbeddedModelArrayField(ArrayField):
             raise ValueError("PolymorphicEmbeddedModelArrayField does not support size.")
         kwargs["editable"] = False
         super().__init__(PolymorphicEmbeddedModelField(embedded_models), **kwargs)
-        self.embedded_models = embedded_models
+        # For consistency, cast list to tuple, if necessary.
+        self.embedded_models = tuple(embedded_models)
 
     def contribute_to_class(self, cls, name, private_only=False, **kwargs):
         super().contribute_to_class(cls, name, private_only=private_only, **kwargs)

--- a/django_mongodb_backend/gis/features.py
+++ b/django_mongodb_backend/gis/features.py
@@ -53,6 +53,11 @@ class GISFeatures(BaseSpatialFeatures):
                     "gis_tests.geoapp.tests.GeoModelTest.test_gis_query_as_string",
                     "gis_tests.geoapp.tests.GeoLookupTest.test_gis_lookups_with_complex_expressions",
                 },
+                "MongoDB doesn't support nested GeometryCollections.": {
+                    # Error: Can't extract geo keys ...
+                    # GeometryCollections cannot be nested
+                    "gis_tests.geoapp.tests.SaveLoadTests.test_geometrycollectionfield_default_max_ignored_on_read",
+                },
                 "GeoJSONSerializer doesn't support ObjectId.": {
                     "gis_tests.geoapp.test_serializers.GeoJSONSerializerTests.test_fields_option",
                     "gis_tests.geoapp.test_serializers.GeoJSONSerializerTests.test_geometry_field_option",

--- a/django_mongodb_backend/transaction.py
+++ b/django_mongodb_backend/transaction.py
@@ -45,6 +45,7 @@ class Atomic(ContextDecorator):
                     connection.commit_mongo()
                 except DatabaseError:
                     connection.rollback_mongo()
+                    raise
         else:
             # atomic() exited with an error.
             if not connection.in_atomic_block_mongo:

--- a/docs/releases/5.2.x.rst
+++ b/docs/releases/5.2.x.rst
@@ -15,7 +15,8 @@ New features
 Bug fixes
 ---------
 
-- ...
+- Prevented :func:`~django_mongodb_backend.transaction.atomic` from silencing
+  exceptions raised on commit.
 
 Performance improvements
 ------------------------

--- a/docs/releases/5.2.x.rst
+++ b/docs/releases/5.2.x.rst
@@ -18,6 +18,11 @@ Bug fixes
 - Prevented :func:`~django_mongodb_backend.transaction.atomic` from silencing
   exceptions raised on commit.
 
+- Fixed crash when saving a model with
+  :class:`~django_mongodb_backend.fields.PolymorphicEmbeddedModelField` or
+  :class:`~django_mongodb_backend.fields.PolymorphicEmbeddedModelArrayField`
+  that specifies ``embedded_models`` as a list of concrete models.
+
 Performance improvements
 ------------------------
 

--- a/docs/releases/5.2.x.rst
+++ b/docs/releases/5.2.x.rst
@@ -5,12 +5,7 @@ Django MongoDB Backend 5.2.x
 5.2.4
 =====
 
-*Unreleased*
-
-New features
-------------
-
-- ...
+*August 24, 2026*
 
 Bug fixes
 ---------

--- a/tests/model_fields_/models.py
+++ b/tests/model_fields_/models.py
@@ -271,6 +271,15 @@ class Cat(EmbeddedModel):
         return self.name
 
 
+class ConcretePerson(models.Model):
+    name = models.CharField(max_length=100)
+    # `embedded_models` is a list of concrete classes, not string references.
+    pet = PolymorphicEmbeddedModelField([Dog, Cat], blank=True, null=True)
+
+    def __str__(self):
+        return self.name
+
+
 class Bone(EmbeddedModel):
     brand = models.CharField(max_length=100)
 
@@ -289,6 +298,15 @@ class Mouse(EmbeddedModel):
 class Owner(models.Model):
     name = models.CharField(max_length=100)
     pets = PolymorphicEmbeddedModelArrayField(("Dog", "Cat"), blank=True, null=True)
+
+    def __str__(self):
+        return self.name
+
+
+class ConcreteOwner(models.Model):
+    name = models.CharField(max_length=100)
+    # `embedded_models` is a list of concrete classes, not string references.
+    pets = PolymorphicEmbeddedModelArrayField([Dog, Cat], blank=True, null=True)
 
     def __str__(self):
         return self.name

--- a/tests/model_fields_/test_polymorphic_embedded_model.py
+++ b/tests/model_fields_/test_polymorphic_embedded_model.py
@@ -9,7 +9,7 @@ from django.test.utils import isolate_apps
 from django_mongodb_backend.fields import PolymorphicEmbeddedModelField
 from django_mongodb_backend.models import EmbeddedModel
 
-from .models import Bone, Cat, Dog, Library, Mouse, Person
+from .models import Bone, Cat, ConcretePerson, Dog, Library, Mouse, Person
 from .utils import truncate_ms
 
 
@@ -28,7 +28,7 @@ class MethodTests(SimpleTestCase):
         self.assertEqual(name, "field_name")
         self.assertEqual(path, "django_mongodb_backend.fields.PolymorphicEmbeddedModelField")
         self.assertEqual(args, [])
-        self.assertEqual(kwargs, {"embedded_models": ["Data"], "null": True})
+        self.assertEqual(kwargs, {"embedded_models": ("Data",), "null": True})
 
     def test_get_db_prep_save_invalid(self):
         msg = (
@@ -78,6 +78,12 @@ class ModelTests(TestCase):
         Person.objects.create(pet=None)
         obj = Person.objects.get()
         self.assertIsNone(obj.pet)
+
+    def test_save_load_concrete(self):
+        ConcretePerson.objects.create(name="Jim", pet=Dog(name="Woofer"))
+        obj = ConcretePerson.objects.get()
+        self.assertIsInstance(obj.pet, Dog)
+        self.assertEqual(obj.pet.name, "Woofer")
 
     def test_save_load_decimal(self):
         obj = Person.objects.create(pet=Cat(name="Phoebe", weight="5.5"))

--- a/tests/model_fields_/test_polymorphic_embedded_model_array.py
+++ b/tests/model_fields_/test_polymorphic_embedded_model_array.py
@@ -8,7 +8,7 @@ from django.test.utils import isolate_apps
 from django_mongodb_backend.fields import PolymorphicEmbeddedModelArrayField
 from django_mongodb_backend.models import EmbeddedModel
 
-from .models import Bone, Cat, Dog, Owner
+from .models import Bone, Cat, ConcreteOwner, Dog, Owner
 
 
 class MethodTests(SimpleTestCase):
@@ -23,7 +23,7 @@ class MethodTests(SimpleTestCase):
         self.assertEqual(name, "field_name")
         self.assertEqual(path, "django_mongodb_backend.fields.PolymorphicEmbeddedModelArrayField")
         self.assertEqual(args, [])
-        self.assertEqual(kwargs, {"embedded_models": ["Dog"], "null": True})
+        self.assertEqual(kwargs, {"embedded_models": ("Dog",), "null": True})
 
     def test_size_not_supported(self):
         msg = "PolymorphicEmbeddedModelArrayField does not support size."
@@ -61,6 +61,15 @@ class ModelTests(TestCase):
         Owner.objects.create(name="Bob")
         owner = Owner.objects.get(name="Bob")
         self.assertIsNone(owner.pets)
+
+    def test_save_load_concrete(self):
+        pets = [Dog(name="Woofer"), Cat(name="Phoebe", weight="3.5")]
+        ConcreteOwner.objects.create(name="Bob", pets=pets)
+        owner = ConcreteOwner.objects.get(name="Bob")
+        self.assertEqual(owner.pets[0].name, "Woofer")
+        self.assertEqual(owner.pets[1].name, "Phoebe")
+        self.assertEqual(owner.pets[1].weight, Decimal("3.5"))
+        self.assertEqual(len(owner.pets), 2)
 
     def test_missing_field_in_data(self):
         """

--- a/tests/transactions_/tests.py
+++ b/tests/transactions_/tests.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 from django.db import DatabaseError, connection
 from django.test import TransactionTestCase, skipIfDBFeature, skipUnlessDBFeature
 
@@ -145,6 +147,17 @@ class AtomicTests(TransactionTestCase):
         connection.close_pool()
         with transaction.atomic():
             pass
+
+    def test_failure_on_commit_transaction(self):
+        """transaction.atomic() re-raises an error during transaction commit."""
+        msg = "commit failed"
+        with (
+            mock.patch.object(connection, "commit_mongo", side_effect=DatabaseError(msg)),
+            self.assertRaisesMessage(DatabaseError, msg),
+            transaction.atomic(),
+        ):
+            Reporter.objects.create(first_name="Tintin")
+        self.assertSequenceEqual(Reporter.objects.all(), [])
 
 
 @skipIfDBFeature("_supports_transactions")


### PR DESCRIPTION
Prepares the 5.2.4 release, planned for Monday, August 24, 2026.

- Set `__version__` to `5.2.4` (from `5.2.4.dev0`).
- Dated the 5.2.4 release notes *August 24, 2026* and dropped the empty "New features" placeholder section.

Jira: https://jira.mongodb.org/browse/INTPYTHON-1063