### PR TITLE
INTPYTHON-1070 Bump pypa/gh-action-pypi-publish to 1.14.2

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -80,14 +80,14 @@ jobs:
           name: all-dist-${{ github.run_id }}
           path: dist/
       - name: Publish package distributions to TestPyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # 1.13.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           repository-url: https://test.pypi.org/legacy/
           skip-existing: true
           attestations: ${{ env.DRY_RUN }}
       - name: Publish package distributions to PyPI
         if: startsWith(env.DRY_RUN, 'false')
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # 1.13.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
 
   post-publish:
     needs: [publish]


### PR DESCRIPTION
[INTPYTHON-1070](https://jira.mongodb.org/browse/INTPYTHON-1070)

## Changes in this PR

Bumps both `pypa/gh-action-pypi-publish` steps in `.github/workflows/release-python.yml` from 1.13.0 to 1.14.2. No API or library code changes.


## Test Plan

Verification is the release workflow re-run: the TestPyPI step runs before the PyPI step, so a successful upload to TestPyPI confirms the fix before anything can reach PyPI. Supporting evidence that the version is sufficient: `main` has been on ≥1.14.0 without hitting this error.

## Checklist

<!-- Do not delete the items provided on this checklist -->

### Checklist for Author

- [ ] Did you update the changelog (if necessary)? — not necessary, CI-only change with no user-visible effect
- [ ] Is the intention of the code captured in relevant tests? — n/a, see Test Plan
- [ ] If there are new TODOs, has a related JIRA ticket been created? — no new TODOs

### Checklist for Reviewer

- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Have you checked for spelling & grammar errors?
- [ ] Is all relevant documentation (README or docstring) updated?
