### PR TITLE
INTPYTHON-1078 Set version to 6.1.1.dev0

### DIFF
--- a/django_mongodb_backend/__init__.py
+++ b/django_mongodb_backend/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "6.2.0.dev0"
+__version__ = "6.1.1.dev0"
 
 # Check Django compatibility before other imports which may fail if the
 # wrong version of Django is installed.


### PR DESCRIPTION
[INTPYTHON-1078](https://jira.mongodb.org/browse/INTPYTHON-1078)

The post-release bump `15feb3a` (`BUMP 6.2.0.dev0`, mongodb-dbx-release-bot) moved `__version__` from `6.1.0` to the next *minor*. `check_django_compatibility()` requires the backend's major.minor to match the installed Django's, so importing `django_mongodb_backend` raises during `django.setup()`.

That bump was a mistake — `main` targets Django 6.1, not 6.2

## Changes in this PR

One line in `django_mongodb_backend/__init__.py`: `__version__` `6.2.0.dev0` → `6.1.1.dev0`.

## Test Plan

## Checklist

<!-- Do not delete the items provided on this checklist -->

### Checklist for Author

- [ ] Did you update the changelog (if necessary)? — not necessary, dev version marker only
- [ ] Is the intention of the code captured in relevant tests? — the whole test suite failing to import was the symptom; it running again is the signal
- [ ] If there are new TODOs, has a related JIRA ticket been created? — no new TODOs

### Checklist for Reviewer

- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Have you checked for spelling & grammar errors?
- [ ] Is all relevant documentation (README or docstring) updated?
