### PR TITLE
INTPYTHON-1079 Skip basic.tests.ModelFromDbTests.test_old_signature_raw

### DIFF
--- a/django_mongodb_backend/features.py
+++ b/django_mongodb_backend/features.py
@@ -690,6 +690,7 @@ class DatabaseFeatures(GISFeatures, BaseDatabaseFeatures):
             "backends.tests.BackendTestCase.test_unicode_fetches",
             "backends.tests.EscapingChecks.test_parameter_escaping",
             "backends.tests.EscapingChecks.test_paramless_no_escaping",
+            "basic.tests.ModelFromDbTests.test_old_signature_raw",
             "composite_pk.tests.CompositePKTests.test_raw",
             "composite_pk.tests.CompositePKTests.test_raw_missing_PK_fields",
             "delete_regress.tests.DeleteLockingTest.test_concurrent_delete",


### PR DESCRIPTION
[INTPYTHON-1079](https://jira.mongodb.org/browse/INTPYTHON-1079)

Django's 6.1.x branch added `ModelFromDbTests.test_old_signature_raw` in upstream commit `cabad83ed1` ("Fixed #37259 -- Restored support for old-signature `Model.from_db()` overrides", 2026-08-08), which reached CI via the `mongodb-forks/django` `mongodb-6.1.x` branch that the test workflows check out unpinned.

The test iterates a raw queryset (`RawModelIterable` → `sql/query.py` → `cursor.execute`), so on MongoDB it raises:

```
django.db.utils.NotSupportedError: MongoDB does not support cursor.execute().
```

That single error makes the `basic` suite exit non-zero, failing the "Django Test Suite" job in all four test workflows (plain, Atlas, Atlas with Encryption, GeoDjango) plus the Evergreen tasks — on `main` and every open PR.

## Changes in this PR

One line in `django_mongodb_backend/features.py`: adds `basic.tests.ModelFromDbTests.test_old_signature_raw` to the existing `(NotSupportedError, "MongoDB does not support cursor.execute().")` bucket in `_django_test_expected_raises`, alongside the ~30 sibling raw-SQL entries.

## Test Plan

CI. The entry asserts the exact exception and message, so it fails if the test ever stops raising `NotSupportedError`.

## Checklist

<!-- Do not delete the items provided on this checklist -->

### Checklist for Author

- [ ] Did you update the changelog (if necessary)? — not necessary, test configuration only
- [ ] Is the intention of the code captured in relevant tests? — the entry *is* the test expectation
- [ ] If there are new TODOs, has a related JIRA ticket been created? — no new TODOs

### Checklist for Reviewer

- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Have you checked for spelling & grammar errors?
- [ ] Is all relevant documentation (README or docstring) updated?
