### PR TITLE
INTPYTHON-1071 Backport CODEOWNERS to the 5.2.x branch

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mongodb/dbx-python


### PR DESCRIPTION
INTPYTHON-1071

## Changes in this PR

Added `.github/CODEOWNERS` to `5.2.x`, matching `main`, so PRs against the release branch auto-request `@mongodb/dbx-python`. The file was added to `main` after `5.2.x` branched off, so the release branch never got it.

## Test Plan

- `git diff upstream/main -- .github/CODEOWNERS` is empty, confirming the backported file matches `main`.
- Opening this PR against `5.2.x` confirms `@mongodb/dbx-python` is auto-requested as a reviewer.

## Checklist

<!-- Do not delete the items provided on this checklist -->

### Checklist for Author

- [ ] Did you update the changelog (if necessary)? — not needed, no user-facing behavior change.
- [ ] Is the intention of the code captured in relevant tests? — no automated test applies to a CODEOWNERS file; verified manually per the test plan above.
- [ ] If there are new TODOs, has a related JIRA ticket been created? — no new TODOs.

### Checklist for Reviewer

- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Have you checked for spelling & grammar errors?
- [ ] Is all relevant documentation (README or docstring) updated?