### PR TITLE
INTPYTHON-1072 Fix PR template location on 5.2.x

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,14 @@
+<!-- Thanks for contributing! -->
+<!-- Please ensure that the title of the PR is in the following form:
+[JIRA TICKET] Issue Title
+
+If you are an external contributor and there is no JIRA ticket associated with your change, then use your best judgement
+for the PR title. A MongoDB employee will create a JIRA ticket and edit the name and links as appropriate.
+
+Note on AI Contributions:
+We only accept pull requests that are authored and submitted by human contributors who fully understand the changes they are proposing.
+All contributions must be written and understood by human contributors. Please read about our policy in our contributing guide.
+-->
 JIRA TICKET
 
 ## Changes in this PR


### PR DESCRIPTION
INTPYTHON-1072

## Changes in this PR

Moves the pull request template from `.github/workflows/PULL_REQUEST_TEMPLATE.md`, where GitHub does not read it, to `.github/PULL_REQUEST_TEMPLATE.md`, and takes main's content, which adds a note on AI contributions.

## Test Plan

Opened this PR against 5.2.x and confirmed the body is pre-filled from the template.

## Checklist

### Checklist for Author

- [x] Did you update the changelog (if necessary)? Not necessary; this is a repo-metadata change.
- [ ] Is the intention of the code captured in relevant tests? No automated test covers PR template location; verified manually by opening this PR.
- [x] If there are new TODOs, has a related JIRA ticket been created?

### Checklist for Reviewer

- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Have you checked for spelling & grammar errors?
- [ ] Is all relevant documentation (README or docstring) updated?